### PR TITLE
Add ModernBERT pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Transformers provides a simple, intuitive interface for Rust developers who want
 - [ModernBERT-zeroshot](https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0)
   - Base
   - Large
+All ModernBERT-based pipelines share the same backbone architecture while loading task-specific finetuned checkpoints.
 
 ## Installation
 

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline.rs
@@ -1,0 +1,17 @@
+use crate::models::modernbert::{FillMaskModernBertModel, ModernBertSize};
+use tokenizers::Tokenizer;
+
+pub struct FillMaskPipeline {
+    pub(crate) model: FillMaskModernBertModel,
+    pub(crate) tokenizer: Tokenizer,
+}
+
+impl FillMaskPipeline {
+    pub fn fill_mask(&self, text: &str) -> anyhow::Result<String> {
+        self.model.predict(&self.tokenizer, text)
+    }
+
+    pub fn get_tokenizer(&self, size: ModernBertSize) -> anyhow::Result<Tokenizer> {
+        self.model.get_tokenizer(size)
+    }
+}

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
@@ -1,0 +1,20 @@
+use super::fill_mask_pipeline::FillMaskPipeline;
+use crate::models::modernbert::{FillMaskModernBertModel, ModernBertSize};
+use crate::pipelines::utils::model_cache::global_cache;
+
+pub struct FillMaskPipelineBuilder {
+    size: ModernBertSize,
+}
+
+impl FillMaskPipelineBuilder {
+    pub fn new(size: ModernBertSize) -> Self {
+        Self { size }
+    }
+
+    pub fn build(self) -> anyhow::Result<FillMaskPipeline> {
+        let key = format!("{:?}", self.size);
+        let model = global_cache().get_or_create(&key, || FillMaskModernBertModel::new(self.size))?;
+        let tokenizer = model.get_tokenizer(self.size)?;
+        Ok(FillMaskPipeline { model, tokenizer })
+    }
+}

--- a/src/pipelines/fill_mask_pipeline/mod.rs
+++ b/src/pipelines/fill_mask_pipeline/mod.rs
@@ -1,0 +1,6 @@
+pub mod fill_mask_pipeline;
+pub mod fill_mask_pipeline_builder;
+
+pub use fill_mask_pipeline_builder::FillMaskPipelineBuilder;
+
+pub use crate::models::modernbert::ModernBertSize;

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -1,3 +1,6 @@
 pub mod utils;
 
 pub mod text_generation_pipeline;
+pub mod fill_mask_pipeline;
+pub mod sentiment_analysis_pipeline;
+pub mod zero_shot_classification_pipeline;

--- a/src/pipelines/sentiment_analysis_pipeline/mod.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/mod.rs
@@ -1,0 +1,8 @@
+pub mod sentiment_analysis_pipeline;
+pub mod sentiment_analysis_pipeline_builder;
+
+pub use sentiment_analysis_pipeline_builder::SentimentAnalysisPipelineBuilder;
+
+pub use crate::models::modernbert::SentimentModernBertSize;
+
+pub use anyhow::Result;

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline.rs
@@ -1,0 +1,17 @@
+use crate::models::modernbert::{SentimentModernBertModel, SentimentModernBertSize};
+use tokenizers::Tokenizer;
+
+pub struct SentimentAnalysisPipeline {
+    pub(crate) model: SentimentModernBertModel,
+    pub(crate) tokenizer: Tokenizer,
+}
+
+impl SentimentAnalysisPipeline {
+    pub fn predict(&self, text: &str) -> anyhow::Result<String> {
+        self.model.predict(&self.tokenizer, text)
+    }
+
+    pub fn get_tokenizer(&self, size: SentimentModernBertSize) -> anyhow::Result<Tokenizer> {
+        self.model.get_tokenizer(size)
+    }
+}

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
@@ -1,0 +1,20 @@
+use super::sentiment_analysis_pipeline::SentimentAnalysisPipeline;
+use crate::models::modernbert::{SentimentModernBertModel, SentimentModernBertSize};
+use crate::pipelines::utils::model_cache::global_cache;
+
+pub struct SentimentAnalysisPipelineBuilder {
+    size: SentimentModernBertSize,
+}
+
+impl SentimentAnalysisPipelineBuilder {
+    pub fn new(size: SentimentModernBertSize) -> Self {
+        Self { size }
+    }
+
+    pub fn build(self) -> anyhow::Result<SentimentAnalysisPipeline> {
+        let key = format!("{:?}", self.size);
+        let model = global_cache().get_or_create(&key, || SentimentModernBertModel::new(self.size))?;
+        let tokenizer = model.get_tokenizer(self.size)?;
+        Ok(SentimentAnalysisPipeline { model, tokenizer })
+    }
+}

--- a/src/pipelines/zero_shot_classification_pipeline/mod.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/mod.rs
@@ -1,0 +1,8 @@
+pub mod zero_shot_classification_pipeline;
+pub mod zero_shot_classification_pipeline_builder;
+
+pub use zero_shot_classification_pipeline_builder::ZeroShotClassificationPipelineBuilder;
+
+pub use crate::models::modernbert::ZeroShotModernBertSize;
+
+pub use anyhow::Result;

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline.rs
@@ -1,0 +1,17 @@
+use crate::models::modernbert::{ZeroShotModernBertModel, ZeroShotModernBertSize};
+use tokenizers::Tokenizer;
+
+pub struct ZeroShotClassificationPipeline {
+    pub(crate) model: ZeroShotModernBertModel,
+    pub(crate) tokenizer: Tokenizer,
+}
+
+impl ZeroShotClassificationPipeline {
+    pub fn predict(&self, text: &str, candidate_labels: &[&str]) -> anyhow::Result<Vec<(String, f32)>> {
+        self.model.predict(&self.tokenizer, text, candidate_labels)
+    }
+
+    pub fn get_tokenizer(&self, size: ZeroShotModernBertSize) -> anyhow::Result<Tokenizer> {
+        self.model.get_tokenizer(size)
+    }
+}

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
@@ -1,0 +1,20 @@
+use super::zero_shot_classification_pipeline::ZeroShotClassificationPipeline;
+use crate::models::modernbert::{ZeroShotModernBertModel, ZeroShotModernBertSize};
+use crate::pipelines::utils::model_cache::global_cache;
+
+pub struct ZeroShotClassificationPipelineBuilder {
+    size: ZeroShotModernBertSize,
+}
+
+impl ZeroShotClassificationPipelineBuilder {
+    pub fn new(size: ZeroShotModernBertSize) -> Self {
+        Self { size }
+    }
+
+    pub fn build(self) -> anyhow::Result<ZeroShotClassificationPipeline> {
+        let key = format!("{:?}", self.size);
+        let model = global_cache().get_or_create(&key, || ZeroShotModernBertModel::new(self.size))?;
+        let tokenizer = model.get_tokenizer(self.size)?;
+        Ok(ZeroShotClassificationPipeline { model, tokenizer })
+    }
+}


### PR DESCRIPTION
## Summary
- add ModernBERT-based fill-mask, sentiment analysis and zero-shot classification
- document that these pipelines all reuse the same ModernBERT backbone

## Testing
- `cargo check`
- `cargo test --lib`
- `cargo test --doc` *(fails: doctest failed)*

------
https://chatgpt.com/codex/tasks/task_e_686314146ce08330868a509e8c864a75