### PR TITLE
Generalize classification pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ fn main() -> anyhow::Result<()> {
     let size = ModernBertSize::Base;
 
     // 2. Build the pipeline
-    let pipeline = FillMaskPipelineBuilder::new(size).build()?;
+    let pipeline = FillMaskPipelineBuilder::modernbert(size).build()?;
 
     // 3. Fill the mask
     let prompt = "The capital of France is [MASK].";
@@ -173,7 +173,7 @@ fn main() -> Result<()> {
     let size = SentimentModernBertSize::Base;
 
     // 2. Build the pipeline
-    let pipeline = SentimentAnalysisPipelineBuilder::new(size).build()?;
+    let pipeline = SentimentAnalysisPipelineBuilder::modernbert(size).build()?;
 
     // 3. Analyze sentiment
     let sentence = "I love using Rust for my projects!";
@@ -198,7 +198,7 @@ fn main() -> Result<()> {
     let size = ZeroShotModernBertSize::Base;
 
     // 2. Build the pipeline
-    let pipeline = ZeroShotClassificationPipelineBuilder::new(size).build()?;
+    let pipeline = ZeroShotClassificationPipelineBuilder::modernbert(size).build()?;
 
     // 3. Classify text using candidate labels
     let text = "The Federal Reserve raised interest rates.";

--- a/examples/zero_shot.rs
+++ b/examples/zero_shot.rs
@@ -5,7 +5,7 @@ fn main() -> Result<()> {
     println!("Building pipeline...");
 
     // 1. Create the pipeline, using the builder to configure the model
-    let mut pipeline = ZeroShotClassificationPipelineBuilder::new(ZeroShotModernBertSize::Base);
+    let mut pipeline = ZeroShotClassificationPipelineBuilder::modernbert(ZeroShotModernBertSize::Base);
 
     println!("Pipeline built successfully.");
 

--- a/src/models/modernbert.rs
+++ b/src/models/modernbert.rs
@@ -737,6 +737,22 @@ impl FillMaskModernBertModel {
     }
 }
 
+impl crate::pipelines::fill_mask_pipeline::fill_mask_model::FillMaskModel for FillMaskModernBertModel {
+    type Options = ModernBertSize;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self> {
+        FillMaskModernBertModel::new(options)
+    }
+
+    fn predict(&self, tokenizer: &Tokenizer, text: &str) -> AnyhowResult<String> {
+        self.predict(tokenizer, text)
+    }
+
+    fn get_tokenizer(options: Self::Options) -> AnyhowResult<Tokenizer> {
+        Self::get_tokenizer(options)
+    }
+}
+
 /// Available sizes of the zero-shot ModernBERT model
 #[derive(Debug, Clone, Copy)]
 pub enum ZeroShotModernBertSize {
@@ -947,6 +963,34 @@ impl ZeroShotModernBertModel {
     }
 }
 
+impl crate::pipelines::zero_shot_classification_pipeline::zero_shot_classification_model::ZeroShotClassificationModel
+    for ZeroShotModernBertModel
+{
+    type Options = ZeroShotModernBertSize;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self> {
+        ZeroShotModernBertModel::new(options)
+    }
+
+    fn predict(
+        &self,
+        tokenizer: &Tokenizer,
+        text: &str,
+        candidate_labels: &[&str],
+    ) -> AnyhowResult<Vec<(String, f32)>> {
+        self.predict(tokenizer, text, candidate_labels)
+    }
+
+    fn get_tokenizer(options: Self::Options) -> AnyhowResult<Tokenizer> {
+        let repo_id = Self::get_tokenizer_repo_info(options);
+        let api = Api::new()?;
+        let repo = api.repo(Repo::new(repo_id, RepoType::Model));
+        let tokenizer_filename = repo.get("tokenizer.json")?;
+        Tokenizer::from_file(tokenizer_filename)
+            .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))
+    }
+}
+
 /// Available ModernBERT Sentiment model sizes.
 #[derive(Debug, Clone, Copy)]
 pub enum SentimentModernBertSize {
@@ -1105,6 +1149,29 @@ impl SentimentModernBertModel {
         let repo = api.repo(Repo::new(repo_id, RepoType::Model));
         let tokenizer_filename = repo.get("tokenizer.json")?;
 
+        Tokenizer::from_file(tokenizer_filename)
+            .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))
+    }
+}
+
+impl crate::pipelines::sentiment_analysis_pipeline::sentiment_analysis_model::SentimentAnalysisModel
+    for SentimentModernBertModel
+{
+    type Options = SentimentModernBertSize;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self> {
+        SentimentModernBertModel::new(options)
+    }
+
+    fn predict(&self, tokenizer: &Tokenizer, text: &str) -> AnyhowResult<String> {
+        self.predict(tokenizer, text)
+    }
+
+    fn get_tokenizer(options: Self::Options) -> AnyhowResult<Tokenizer> {
+        let repo_id = Self::get_tokenizer_repo_info(options);
+        let api = Api::new()?;
+        let repo = api.repo(Repo::new(repo_id, RepoType::Model));
+        let tokenizer_filename = repo.get("tokenizer.json")?;
         Tokenizer::from_file(tokenizer_filename)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))
     }

--- a/src/pipelines/fill_mask_pipeline/fill_mask_model.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_model.rs
@@ -1,0 +1,13 @@
+use tokenizers::Tokenizer;
+
+pub trait FillMaskModel {
+    type Options: std::fmt::Debug + Clone;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    fn predict(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<String>;
+
+    fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer>;
+}

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline.rs
@@ -1,12 +1,12 @@
-use crate::models::modernbert::FillMaskModernBertModel;
+use super::fill_mask_model::FillMaskModel;
 use tokenizers::Tokenizer;
 
-pub struct FillMaskPipeline {
-    pub(crate) model: FillMaskModernBertModel,
+pub struct FillMaskPipeline<M: FillMaskModel> {
+    pub(crate) model: M,
     pub(crate) tokenizer: Tokenizer,
 }
 
-impl FillMaskPipeline {
+impl<M: FillMaskModel> FillMaskPipeline<M> {
     pub fn fill_mask(&self, text: &str) -> anyhow::Result<String> {
         self.model.predict(&self.tokenizer, text)
     }

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
@@ -1,21 +1,29 @@
+use super::fill_mask_model::FillMaskModel;
 use super::fill_mask_pipeline::FillMaskPipeline;
-use crate::models::modernbert::{FillMaskModernBertModel, ModernBertSize};
 use crate::pipelines::utils::model_cache::global_cache;
 
-pub struct FillMaskPipelineBuilder {
-    size: ModernBertSize,
+pub struct FillMaskPipelineBuilder<M: FillMaskModel> {
+    options: M::Options,
 }
 
-impl FillMaskPipelineBuilder {
-    pub fn new(size: ModernBertSize) -> Self {
-        Self { size }
+impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
+    pub fn new(options: M::Options) -> Self {
+        Self { options }
     }
 
-    pub fn build(self) -> anyhow::Result<FillMaskPipeline> {
-        let key = format!("{:?}", self.size);
-        let model =
-            global_cache().get_or_create(&key, || FillMaskModernBertModel::new(self.size))?;
-        let tokenizer = FillMaskModernBertModel::get_tokenizer(self.size)?;
+    pub fn build(self) -> anyhow::Result<FillMaskPipeline<M>>
+    where
+        M: Clone + Send + Sync + 'static,
+    {
+        let key = format!("{:?}", self.options);
+        let model = global_cache().get_or_create(&key, || M::new(self.options.clone()))?;
+        let tokenizer = M::get_tokenizer(self.options)?;
         Ok(FillMaskPipeline { model, tokenizer })
+    }
+}
+
+impl FillMaskPipelineBuilder<crate::models::modernbert::FillMaskModernBertModel> {
+    pub fn modernbert(size: crate::models::modernbert::ModernBertSize) -> Self {
+        Self::new(size)
     }
 }

--- a/src/pipelines/fill_mask_pipeline/mod.rs
+++ b/src/pipelines/fill_mask_pipeline/mod.rs
@@ -1,6 +1,8 @@
+pub mod fill_mask_model;
 pub mod fill_mask_pipeline;
 pub mod fill_mask_pipeline_builder;
 
 pub use fill_mask_pipeline_builder::FillMaskPipelineBuilder;
+pub use fill_mask_model::FillMaskModel;
 
 pub use crate::models::modernbert::ModernBertSize;

--- a/src/pipelines/sentiment_analysis_pipeline/mod.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/mod.rs
@@ -1,7 +1,9 @@
+pub mod sentiment_analysis_model;
 pub mod sentiment_analysis_pipeline;
 pub mod sentiment_analysis_pipeline_builder;
 
 pub use sentiment_analysis_pipeline_builder::SentimentAnalysisPipelineBuilder;
+pub use sentiment_analysis_model::SentimentAnalysisModel;
 
 pub use crate::models::modernbert::SentimentModernBertSize;
 

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_model.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_model.rs
@@ -1,0 +1,13 @@
+use tokenizers::Tokenizer;
+
+pub trait SentimentAnalysisModel {
+    type Options: std::fmt::Debug + Clone;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    fn predict(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<String>;
+
+    fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer>;
+}

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline.rs
@@ -1,12 +1,12 @@
-use crate::models::modernbert::{SentimentModernBertModel, SentimentModernBertSize};
+use super::sentiment_analysis_model::SentimentAnalysisModel;
 use tokenizers::Tokenizer;
 
-pub struct SentimentAnalysisPipeline {
-    pub(crate) model: SentimentModernBertModel,
+pub struct SentimentAnalysisPipeline<M: SentimentAnalysisModel> {
+    pub(crate) model: M,
     pub(crate) tokenizer: Tokenizer,
 }
 
-impl SentimentAnalysisPipeline {
+impl<M: SentimentAnalysisModel> SentimentAnalysisPipeline<M> {
     pub fn predict(&self, text: &str) -> anyhow::Result<String> {
         self.model.predict(&self.tokenizer, text)
     }

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
@@ -1,20 +1,29 @@
+use super::sentiment_analysis_model::SentimentAnalysisModel;
 use super::sentiment_analysis_pipeline::SentimentAnalysisPipeline;
-use crate::models::modernbert::{SentimentModernBertModel, SentimentModernBertSize};
 use crate::pipelines::utils::model_cache::global_cache;
 
-pub struct SentimentAnalysisPipelineBuilder {
-    size: SentimentModernBertSize,
+pub struct SentimentAnalysisPipelineBuilder<M: SentimentAnalysisModel> {
+    options: M::Options,
 }
 
-impl SentimentAnalysisPipelineBuilder {
-    pub fn new(size: SentimentModernBertSize) -> Self {
-        Self { size }
+impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
+    pub fn new(options: M::Options) -> Self {
+        Self { options }
     }
 
-    pub fn build(self) -> anyhow::Result<SentimentAnalysisPipeline> {
-        let key = format!("{:?}", self.size);
-        let model = global_cache().get_or_create(&key, || SentimentModernBertModel::new(self.size))?;
-        let tokenizer = model.get_tokenizer(self.size)?;
+    pub fn build(self) -> anyhow::Result<SentimentAnalysisPipeline<M>>
+    where
+        M: Clone + Send + Sync + 'static,
+    {
+        let key = format!("{:?}", self.options);
+        let model = global_cache().get_or_create(&key, || M::new(self.options.clone()))?;
+        let tokenizer = M::get_tokenizer(self.options)?;
         Ok(SentimentAnalysisPipeline { model, tokenizer })
+    }
+}
+
+impl SentimentAnalysisPipelineBuilder<crate::models::modernbert::SentimentModernBertModel> {
+    pub fn modernbert(size: crate::models::modernbert::SentimentModernBertSize) -> Self {
+        Self::new(size)
     }
 }

--- a/src/pipelines/zero_shot_classification_pipeline/mod.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/mod.rs
@@ -1,7 +1,9 @@
+pub mod zero_shot_classification_model;
 pub mod zero_shot_classification_pipeline;
 pub mod zero_shot_classification_pipeline_builder;
 
 pub use zero_shot_classification_pipeline_builder::ZeroShotClassificationPipelineBuilder;
+pub use zero_shot_classification_model::ZeroShotClassificationModel;
 
 pub use crate::models::modernbert::ZeroShotModernBertSize;
 

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_model.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_model.rs
@@ -1,0 +1,18 @@
+use tokenizers::Tokenizer;
+
+pub trait ZeroShotClassificationModel {
+    type Options: std::fmt::Debug + Clone;
+
+    fn new(options: Self::Options) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    fn predict(
+        &self,
+        tokenizer: &Tokenizer,
+        text: &str,
+        candidate_labels: &[&str],
+    ) -> anyhow::Result<Vec<(String, f32)>>;
+
+    fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer>;
+}

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline.rs
@@ -1,17 +1,13 @@
-use crate::models::modernbert::{ZeroShotModernBertModel, ZeroShotModernBertSize};
+use super::zero_shot_classification_model::ZeroShotClassificationModel;
 use tokenizers::Tokenizer;
 
-pub struct ZeroShotClassificationPipeline {
-    pub(crate) model: ZeroShotModernBertModel,
+pub struct ZeroShotClassificationPipeline<M: ZeroShotClassificationModel> {
+    pub(crate) model: M,
     pub(crate) tokenizer: Tokenizer,
 }
 
-impl ZeroShotClassificationPipeline {
+impl<M: ZeroShotClassificationModel> ZeroShotClassificationPipeline<M> {
     pub fn predict(&self, text: &str, candidate_labels: &[&str]) -> anyhow::Result<Vec<(String, f32)>> {
         self.model.predict(&self.tokenizer, text, candidate_labels)
-    }
-
-    pub fn get_tokenizer(&self, size: ZeroShotModernBertSize) -> anyhow::Result<Tokenizer> {
-        self.model.get_tokenizer(size)
     }
 }


### PR DESCRIPTION
## Summary
- add generic traits for zero-shot, fill-mask, and sentiment pipelines
- implement these traits for ModernBERT models
- update pipeline builders to work generically and provide `modernbert` helpers
- adjust example and README to use new helpers