### PR TITLE
Add test for caching of weights across multiple pipelines

### DIFF
--- a/tests/multi_pipeline.rs
+++ b/tests/multi_pipeline.rs
@@ -1,0 +1,34 @@
+use transformers::pipelines::text_generation_pipeline::*;
+use transformers::models::quantized_qwen3::Qwen3Size;
+use transformers::pipelines::utils::model_cache::global_cache;
+
+#[test]
+fn multiple_pipelines_share_weights_and_have_independent_caches() -> anyhow::Result<()> {
+    // Ensure the cache is clean so we can accurately count models
+    global_cache().clear();
+
+    let mut pipelines = Vec::new();
+    for _ in 0..10 {
+        let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+            .temperature(0.7)
+            .max_len(10)
+            .build()?;
+        pipelines.push(pipeline);
+    }
+
+    // Only one model should be loaded
+    assert_eq!(global_cache().len(), 1);
+
+    let prompt = "Hello, world!";
+    let _ = pipelines[0].prompt_completion(prompt)?;
+
+    // The first pipeline should have advanced its context
+    assert!(pipelines[0].context_position() > 0);
+
+    // Other pipelines should remain untouched
+    for (idx, p) in pipelines.iter().enumerate().skip(1) {
+        assert_eq!(p.context_position(), 0, "pipeline {} reused context", idx + 1);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `tests/multi_pipeline.rs` to ensure that multiple pipelines built for the same model share cached weights while using independent KV caches