### PR TITLE
Simplify XML builder API

### DIFF
--- a/examples/xml_parser.rs
+++ b/examples/xml_parser.rs
@@ -2,15 +2,10 @@ use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
 
 fn main() -> Result<()> {
-    // Create an XML parser with tags to watch for
-    let mut xml_parser_builder = XmlParserBuilder::new();
-    let think_tag = xml_parser_builder.register_tag("think");
-    let xml_parser = xml_parser_builder.build();
-
     // Build a pipeline with XML parsing capabilities
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(1024)
-        .build_xml(xml_parser)?;
+        .build_xml(&["think"])?;
 
     // Generate completion - this will return Vec<Event>
     let events = pipeline.completion("Solve this math problem step by step: What is 15% of 80?")?;
@@ -18,7 +13,7 @@ fn main() -> Result<()> {
     println!("\n--- Generated Events ---");
     for event in events {
         match event.tag() {
-            Some(tag) if tag == &think_tag => {
+            Some("think") => {
                 println!("[THINKING] {}", event.get_content());
             }
             _ => {

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -3,16 +3,10 @@ use transformers::pipelines::text_generation_pipeline::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Create an XML parser with tags to watch for
-    let mut xml_parser_builder = XmlParserBuilder::new();
-    let think_tag = xml_parser_builder.register_tag("think");
-    let tool_response_tag = xml_parser_builder.register_tag("tool_response");
-    let xml_parser = xml_parser_builder.build();
-
     // Build a pipeline with XML parsing capabilities
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(1024)
-        .build_xml(xml_parser)?;
+        .build_xml(&["think", "tool_response"])?;
 
     // Stream completion - this will yield Event items
     let mut stream = pipeline.completion_stream(
@@ -22,10 +16,10 @@ async fn main() -> Result<()> {
     println!("\n--- Streaming Events ---");
     while let Some(event) = stream.next().await {
         match event.tag() {
-            Some(tag) if tag == &think_tag => {
+            Some("think") => {
                 print!("[THINKING] {}", event.get_content());
             }
-            Some(tag) if tag == &tool_response_tag => {
+            Some("tool_response") => {
                 print!("[TOOL] {}", event.get_content());
             }
             _ => {

--- a/src/pipelines/text_generation_pipeline/text_generation_pipeline_builder.rs
+++ b/src/pipelines/text_generation_pipeline/text_generation_pipeline_builder.rs
@@ -5,7 +5,7 @@ use crate::pipelines::utils::model_cache::global_cache;
 use super::text_generation_model::TextGenerationModel;
 use super::text_generation_pipeline::TextGenerationPipeline;
 use super::xml_generation_pipeline::XmlGenerationPipeline;
-use super::xml_parser::XmlParser;
+use super::xml_parser::{XmlParser, XmlParserBuilder};
 
 pub struct TextGenerationPipelineBuilder<M: TextGenerationModel> {
     model_options: M::Options,
@@ -101,7 +101,7 @@ impl<M: TextGenerationModel> TextGenerationPipelineBuilder<M> {
         TextGenerationPipeline::new(model, gen_params)
     }
 
-    pub fn build_xml(self, xml_parser: XmlParser) -> anyhow::Result<XmlGenerationPipeline<M>>
+    pub fn build_xml(self, tags: &[&str]) -> anyhow::Result<XmlGenerationPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: std::fmt::Display,
@@ -124,6 +124,12 @@ impl<M: TextGenerationModel> TextGenerationPipelineBuilder<M> {
             self.top_k.unwrap_or(default_params.top_k),
             self.min_p.unwrap_or(default_params.min_p),
         );
+
+        let mut builder = XmlParserBuilder::new();
+        for tag in tags {
+            builder.register_tag(*tag);
+        }
+        let xml_parser = builder.build();
 
         XmlGenerationPipeline::new(model, gen_params, xml_parser)
     }

--- a/src/pipelines/text_generation_pipeline/xml_parser.rs
+++ b/src/pipelines/text_generation_pipeline/xml_parser.rs
@@ -75,8 +75,16 @@ impl Event {
         }
     }
 
-    /// Get the tag if this is a tagged event
-    pub fn tag(&self) -> Option<&Tag> {
+    /// Get the tag name if this is a tagged event
+    pub fn tag(&self) -> Option<&str> {
+        match self {
+            Event::Tagged { tag, .. } => Some(tag.name()),
+            Event::Content(_) => None,
+        }
+    }
+
+    /// Get the internal tag handle if needed
+    pub fn tag_handle(&self) -> Option<&Tag> {
         match self {
             Event::Tagged { tag, .. } => Some(tag),
             Event::Content(_) => None,


### PR DESCRIPTION
## Summary
- take string tags for XML pipeline builder
- expose tag name instead of handle
- update XML examples