### PR TITLE
Implement cache keys, streaming helper, and new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Transformers provides a simple, intuitive interface for Rust developers who want
 
 All ModernBERT-based pipelines share the same backbone architecture while loading task-specific finetuned checkpoints.
 
+## Pipeline Feature Matrix
+
+| Pipeline | Models | Streaming | Tools | Context Management |
+|----------|--------|-----------|-------|--------------------|
+| Text Generation | Qwen3, Gemma3 | ✓ | ✓ | ✓ |
+| Sentiment | ModernBERT | ✗ | ✗ | ✗ |
+| Fill Mask | ModernBERT | ✗ | ✗ | ✗ |
+| Zero-Shot | ModernBERT | ✗ | ✗ | ✗ |
+
 ## Usage
 
 At this point in development the only way to interact with the models is through the given pipelines, I plan to eventually provide a simple interface to work with the models directly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,8 @@
-#![allow(warnings)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_variables)]
-#![allow(unused_mut)]
 
 mod loaders;
 mod models;
 pub mod pipelines;
 
-pub(crate) const DEFAULT_TEMPERATURE: f64 = 0.7;
-pub(crate) const DEFAULT_REPEAT_PENALTY: f32 = 1.1;
-pub(crate) const DEFAULT_REPEAT_LAST_N: usize = 64;
-pub(crate) const DEFAULT_SEED: u64 = 299792458;
 
 // Re-export the `#[tool]` procedural macro so users can simply write
 // `use transformers::tool;` and annotate their functions without adding an

--- a/src/models/modernbert.rs
+++ b/src/models/modernbert.rs
@@ -633,6 +633,15 @@ pub enum ModernBertSize {
     Large,
 }
 
+impl crate::pipelines::utils::model_cache::ModelOptions for ModernBertSize {
+    fn cache_key(&self) -> String {
+        match self {
+            ModernBertSize::Base => "modernbert-base".to_string(),
+            ModernBertSize::Large => "modernbert-large".to_string(),
+        }
+    }
+}
+
 /// Fill-mask model using ModernBERT.
 #[derive(Clone)]
 pub struct FillMaskModernBertModel {

--- a/src/models/quantized_gemma3.rs
+++ b/src/models/quantized_gemma3.rs
@@ -607,6 +607,12 @@ impl std::fmt::Display for Gemma3Size {
     }
 }
 
+impl crate::pipelines::utils::model_cache::ModelOptions for Gemma3Size {
+    fn cache_key(&self) -> String {
+        self.to_string()
+    }
+}
+
 use crate::loaders::{GgufModelLoader, TokenizerLoader};
 use tokenizers::Tokenizer;
 
@@ -909,7 +915,6 @@ use crate::pipelines::text_generation_pipeline::text_generation_model::{
 };
 
 use minijinja::{context, Environment};
-use serde_json::Value;
 
 impl LanguageModelContext for Context {
     fn generate(&mut self, input: &Tensor) -> candle_core::Result<Tensor> {

--- a/src/models/quantized_qwen3.rs
+++ b/src/models/quantized_qwen3.rs
@@ -544,6 +544,12 @@ impl std::fmt::Display for Qwen3Size {
     }
 }
 
+impl crate::pipelines::utils::model_cache::ModelOptions for Qwen3Size {
+    fn cache_key(&self) -> String {
+        self.to_string()
+    }
+}
+
 use crate::loaders::{GgufModelLoader, TokenizerLoader};
 
 /// High-level Qwen3 model interface for text generation.
@@ -816,7 +822,6 @@ use crate::pipelines::text_generation_pipeline::text_generation_model::{
     LanguageModelContext, TextGenerationModel, ToggleableReasoning, ToolCalling,
 };
 
-use serde_json::Value;
 
 impl LanguageModelContext for Context {
     fn generate(&mut self, input: &Tensor) -> candle_core::Result<Tensor> {

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
@@ -1,6 +1,6 @@
 use super::fill_mask_model::FillMaskModel;
 use super::fill_mask_pipeline::FillMaskPipeline;
-use crate::pipelines::utils::model_cache::global_cache;
+use crate::pipelines::utils::model_cache::{global_cache, ModelOptions};
 
 pub struct FillMaskPipelineBuilder<M: FillMaskModel> {
     options: M::Options,
@@ -14,8 +14,9 @@ impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
     pub fn build(self) -> anyhow::Result<FillMaskPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
+        M::Options: ModelOptions + Clone,
     {
-        let key = format!("{:?}", self.options);
+        let key = self.options.cache_key();
         let model = global_cache().get_or_create(&key, || M::new(self.options.clone()))?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(FillMaskPipeline { model, tokenizer })

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
@@ -1,6 +1,6 @@
 use super::sentiment_analysis_model::SentimentAnalysisModel;
 use super::sentiment_analysis_pipeline::SentimentAnalysisPipeline;
-use crate::pipelines::utils::model_cache::global_cache;
+use crate::pipelines::utils::model_cache::{global_cache, ModelOptions};
 
 pub struct SentimentAnalysisPipelineBuilder<M: SentimentAnalysisModel> {
     options: M::Options,
@@ -14,8 +14,9 @@ impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
     pub fn build(self) -> anyhow::Result<SentimentAnalysisPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
+        M::Options: ModelOptions + Clone,
     {
-        let key = format!("{:?}", self.options);
+        let key = self.options.cache_key();
         let model = global_cache().get_or_create(&key, || M::new(self.options.clone()))?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(SentimentAnalysisPipeline { model, tokenizer })

--- a/src/pipelines/text_generation_pipeline/completion_stream.rs
+++ b/src/pipelines/text_generation_pipeline/completion_stream.rs
@@ -1,0 +1,45 @@
+use futures::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Convenience wrapper around the streaming output of [`TextGenerationPipeline`].
+pub struct CompletionStream<'a> {
+    inner: Pin<Box<dyn Stream<Item = String> + Send + 'a>>,
+}
+
+impl<'a> CompletionStream<'a> {
+    pub(crate) fn new(inner: Pin<Box<dyn Stream<Item = String> + Send + 'a>>) -> Self {
+        Self { inner }
+    }
+
+    /// Collect the entire stream into a single `String`.
+    pub async fn collect(mut self) -> String {
+        use futures::StreamExt;
+        let mut out = String::new();
+        while let Some(chunk) = self.inner.next().await {
+            out.push_str(&chunk);
+        }
+        out
+    }
+
+    /// Take the first `n` chunks from the stream.
+    pub async fn take(mut self, n: usize) -> Vec<String> {
+        use futures::StreamExt;
+        let mut out = Vec::new();
+        for _ in 0..n {
+            match self.inner.next().await {
+                Some(chunk) => out.push(chunk),
+                None => break,
+            }
+        }
+        out
+    }
+}
+
+impl<'a> Stream for CompletionStream<'a> {
+    type Item = String;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next(cx)
+    }
+}

--- a/src/pipelines/text_generation_pipeline/mod.rs
+++ b/src/pipelines/text_generation_pipeline/mod.rs
@@ -5,11 +5,13 @@ pub mod text_generation_pipeline_builder;
 pub mod tool_error;
 pub mod xml_generation_pipeline;
 pub mod xml_parser;
+pub mod completion_stream;
 
 pub use crate::tools;
 pub use text_generation_pipeline::{Input, TextGenerationPipeline};
 pub use text_generation_pipeline_builder::TextGenerationPipelineBuilder;
 pub use xml_generation_pipeline::XmlGenerationPipeline;
+pub use completion_stream::CompletionStream;
 
 // Convenience re-exports so users can simply
 // `use transformers::pipelines::text_generation_pipeline::*;` and access

--- a/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
@@ -14,7 +14,7 @@ use futures::Stream;
 use regex::Regex;
 use serde::Deserialize;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// XML generation pipeline that outputs parsed Events
 pub struct XmlGenerationPipeline<M: TextGenerationModel> {
@@ -607,7 +607,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
 
         let messages = vec![crate::Message::user(prompt)];
         Ok(stream! {
-            let mut messages = messages;
+            let messages = messages;
 
             let stream = self
                 .message_completion_stream_with_tools(&messages[..])
@@ -632,7 +632,6 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
         }
 
         let initial_messages = messages.to_vec();
-        let parser = self.xml_parser.clone();
 
         Ok(stream! {
             let mut messages = initial_messages;

--- a/src/pipelines/utils/model_cache.rs
+++ b/src/pipelines/utils/model_cache.rs
@@ -8,6 +8,11 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+/// Trait implemented by model option types to generate a stable cache key.
+pub trait ModelOptions {
+    fn cache_key(&self) -> String;
+}
+
 /// A thread-safe cache for model instances.
 ///
 /// The cache stores models by a string key (typically the model size/variant)

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
@@ -1,6 +1,6 @@
 use super::zero_shot_classification_model::ZeroShotClassificationModel;
 use super::zero_shot_classification_pipeline::ZeroShotClassificationPipeline;
-use crate::pipelines::utils::model_cache::global_cache;
+use crate::pipelines::utils::model_cache::{global_cache, ModelOptions};
 
 pub struct ZeroShotClassificationPipelineBuilder<M: ZeroShotClassificationModel> {
     options: M::Options,
@@ -14,8 +14,9 @@ impl<M: ZeroShotClassificationModel> ZeroShotClassificationPipelineBuilder<M> {
     pub fn build(self) -> anyhow::Result<ZeroShotClassificationPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
+        M::Options: ModelOptions + Clone,
     {
-        let key = format!("{:?}", self.options);
+        let key = self.options.cache_key();
         let model = global_cache().get_or_create(&key, || M::new(self.options.clone()))?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(ZeroShotClassificationPipeline { model, tokenizer })

--- a/tests/pipeline_tests.rs
+++ b/tests/pipeline_tests.rs
@@ -76,3 +76,90 @@ fn basic_sentiment() -> anyhow::Result<()> {
     assert!(!res.trim().is_empty());
     Ok(())
 }
+
+#[test]
+fn test_context_overflow_recovery() -> anyhow::Result<()> {
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(4)
+        .build()?;
+
+    let max_ctx = pipeline.max_context_length();
+
+    // Generate repeatedly until we exceed the context
+    for _ in 0..(max_ctx / 2 + 2) {
+        let _ = pipeline.completion("hello")?;
+    }
+
+    // Context should be less than the limit after auto reset
+    assert!(pipeline.context_position() < max_ctx);
+    Ok(())
+}
+
+#[tool(on_error = ErrorStrategy::Fail, retries = 1)]
+fn fail_tool() -> Result<String, ToolError> {
+    Err(ToolError::Message("boom".into()))
+}
+
+#[tool(on_error = ErrorStrategy::ReturnToModel, retries = 1)]
+fn fail_tool_model() -> Result<String, ToolError> {
+    Err(ToolError::Message("boom".into()))
+}
+
+#[test]
+fn test_tool_error_strategies() -> anyhow::Result<()> {
+    // Fail strategy should propagate the error
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(32)
+        .build()?;
+    pipeline.register_tools(tools![fail_tool])?;
+    assert!(pipeline.completion_with_tools("call fail_tool").is_err());
+
+    // ReturnToModel strategy should succeed with error message in output
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(32)
+        .build()?;
+    pipeline.register_tools(tools![fail_tool_model])?;
+    let out = pipeline.completion_with_tools("call fail_tool_model")?;
+    assert!(out.contains("Error:"));
+    Ok(())
+}
+
+#[test]
+fn test_empty_input_handling() -> anyhow::Result<()> {
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(4)
+        .build()?;
+    let out = pipeline.completion("")?;
+    assert!(!out.trim().is_empty());
+
+    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+    let res = pipeline.fill_mask("")?;
+    assert!(!res.trim().is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_token_limit_edge_cases() -> anyhow::Result<()> {
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(8)
+        .build()?;
+
+    let max_ctx = pipeline.max_context_length();
+    let prompt = "hello";
+
+    // Fill up to exactly the limit
+    while pipeline.context_position() + 2 < max_ctx {
+        let _ = pipeline.completion(prompt)?;
+    }
+
+    // Next generation should still work and reset when hitting the limit
+    let _ = pipeline.completion(prompt)?;
+    assert!(pipeline.context_position() < max_ctx);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add ModelOptions trait for generating stable cache keys
- implement cache_key for ModernBERT, Qwen3, and Gemma3 models
- introduce `CompletionStream` wrapper for streaming APIs
- document supported features in a Pipeline Feature Matrix
- expose `max_context_length` and add several regression tests
- remove unused imports/constants

## Testing
- `cargo test --quiet` *(fails: Connection Failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6865df487f988330a3fed941c88ac5b2