### PR TITLE
Improve XML streaming events

### DIFF
--- a/examples/xml_parser.rs
+++ b/examples/xml_parser.rs
@@ -36,13 +36,11 @@ fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
-            _ => {
-                if event.part() == TagParts::Content {
-                    println!("[OUTPUT]");
-                    print!("{}", event.get_content());
-                    println!("\n[END OUTPUT]");
-                }
-            }
+            _ => match event.part() {
+                TagParts::Start => println!("[OUTPUT]"),
+                TagParts::Content => print!("{}", event.get_content()),
+                TagParts::End => println!("\n[END OUTPUT]"),
+            },
         }
     }
 

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -50,13 +50,11 @@ async fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
-            _ => {
-                if event.part() == TagParts::Content {
-                    println!("[OUTPUT]");
-                    print!("{}", event.get_content());
-                    println!("[END OUTPUT]");
-                }
-            }
+            _ => match event.part() {
+                TagParts::Start => println!("[OUTPUT]"),
+                TagParts::Content => print!("{}", event.get_content()),
+                TagParts::End => println!("[END OUTPUT]"),
+            },
         }
         std::io::stdout().flush().unwrap();
     }


### PR DESCRIPTION
## Summary
- add explicit start and end events for plain text
- update examples to consume new events
- adjust XML parser tests for new behavior

## Testing
- `cargo fmt --all`
- `cargo test --lib`
- `cargo test` *(fails: multiple_pipelines_share_weights_and_have_independent_caches)*

------
https://chatgpt.com/codex/tasks/task_e_6867236e43588330839a0383d35c49a1