### PR TITLE
Add generation parameter setter

### DIFF
--- a/src/pipelines/text_generation_pipeline/base_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/base_pipeline.rs
@@ -13,7 +13,7 @@ pub struct BasePipeline<M: TextGenerationModel> {
     pub model: Arc<Mutex<M>>,
     pub model_tokenizer: Tokenizer,
     pub context: Arc<Mutex<M::Context>>,
-    pub gen_params: GenerationParams,
+    pub gen_params: Arc<Mutex<GenerationParams>>,
     pub device: candle_core::Device,
     pub last_processed_tokens: Arc<Mutex<Vec<u32>>>,
     pub special_strings: std::collections::HashSet<String>,
@@ -42,7 +42,7 @@ impl<M: TextGenerationModel> BasePipeline<M> {
             model: Arc::new(Mutex::new(model)),
             model_tokenizer,
             context: Arc::new(Mutex::new(context)),
-            gen_params,
+            gen_params: Arc::new(Mutex::new(gen_params)),
             device,
             last_processed_tokens: Arc::new(Mutex::new(Vec::new())),
             special_strings,
@@ -54,6 +54,10 @@ impl<M: TextGenerationModel> BasePipeline<M> {
         self.context.lock().unwrap().position()
     }
 
+    pub fn set_generation_params(&self, params: GenerationParams) {
+        *self.gen_params.lock().unwrap() = params;
+    }
+
     pub fn can_reuse_cache(&self, new_tokens: &[u32]) -> bool {
         // Cache can be reused if the new prompt begins with the exact token
         // sequence that is already cached.
@@ -63,10 +67,11 @@ impl<M: TextGenerationModel> BasePipeline<M> {
     pub fn completion_from_tokens(&self, input_tokens: &[u32]) -> anyhow::Result<String> {
         const CHUNK_SIZE: usize = 64; // Must be <= initial kv cache size
 
-        let mut logits_processor =
-            initialize_logits_processor(&self.gen_params, self.gen_params.seed);
+        let params = self.gen_params.lock().unwrap().clone();
 
-        let mut generated_tokens: Vec<u32> = Vec::with_capacity(self.gen_params.max_len);
+        let mut logits_processor = initialize_logits_processor(&params, params.seed);
+
+        let mut generated_tokens: Vec<u32> = Vec::with_capacity(params.max_len);
 
         // Feed the initial prompt in manageable chunks to allow the KV cache to grow.
         let mut idx = 0;
@@ -90,7 +95,7 @@ impl<M: TextGenerationModel> BasePipeline<M> {
 
         // Generate autoregressively
         let eos_tokens = self.model.lock().unwrap().get_eos_tokens();
-        for _ in 0..self.gen_params.max_len {
+        for _ in 0..params.max_len {
             if eos_tokens.contains(&next_token) {
                 break;
             }
@@ -102,15 +107,13 @@ impl<M: TextGenerationModel> BasePipeline<M> {
             }?;
             let logits = logits.squeeze(0)?;
 
-            let start_at = generated_tokens
-                .len()
-                .saturating_sub(self.gen_params.repeat_last_n);
+            let start_at = generated_tokens.len().saturating_sub(params.repeat_last_n);
             let penalty_context = &generated_tokens[start_at..];
 
-            let logits = if self.gen_params.repeat_penalty <= 1. || penalty_context.is_empty() {
+            let logits = if params.repeat_penalty <= 1. || penalty_context.is_empty() {
                 logits
             } else {
-                apply_repeat_penalty(&logits, self.gen_params.repeat_penalty, penalty_context)?
+                apply_repeat_penalty(&logits, params.repeat_penalty, penalty_context)?
             };
 
             next_token = logits_processor.sample(&logits)?;

--- a/src/pipelines/text_generation_pipeline/mod.rs
+++ b/src/pipelines/text_generation_pipeline/mod.rs
@@ -1,23 +1,24 @@
 pub mod base_pipeline;
+pub mod completion_stream;
 pub mod text_generation_model;
 pub mod text_generation_pipeline;
 pub mod text_generation_pipeline_builder;
 pub mod tool_error;
 pub mod xml_generation_pipeline;
 pub mod xml_parser;
-pub mod completion_stream;
 
 pub use crate::tools;
+pub use completion_stream::CompletionStream;
 pub use text_generation_pipeline::{Input, TextGenerationPipeline};
 pub use text_generation_pipeline_builder::TextGenerationPipelineBuilder;
 pub use xml_generation_pipeline::XmlGenerationPipeline;
-pub use completion_stream::CompletionStream;
 
 // Convenience re-exports so users can simply
 // `use transformers::pipelines::text_generation_pipeline::*;` and access
 // the common model size enums and the `#[tool]` macro without additional
 // import clutter.
 
+pub use crate::models::generation::GenerationParams;
 pub use crate::models::quantized_gemma3::Gemma3Size;
 pub use crate::models::quantized_qwen3::Qwen3Size;
 
@@ -40,7 +41,7 @@ pub use anyhow::Result;
 pub use std::io::Write;
 
 pub use tool_error::ToolError;
-pub use xml_parser::{Event, XmlParser, XmlParserBuilder, TagParts};
+pub use xml_parser::{Event, TagParts, XmlParser, XmlParserBuilder};
 
 #[macro_export]
 macro_rules! tools {

--- a/src/pipelines/text_generation_pipeline/text_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/text_generation_pipeline.rs
@@ -61,6 +61,10 @@ impl<M: TextGenerationModel> TextGenerationPipeline<M> {
         self.base.context_position()
     }
 
+    pub fn set_generation_params(&self, params: GenerationParams) {
+        self.base.set_generation_params(params);
+    }
+
     /// Return the maximum context length supported by the model.
     pub fn max_context_length(&self) -> usize {
         self.base.model.lock().unwrap().get_max_seq_len()
@@ -245,7 +249,7 @@ impl<M: TextGenerationModel> TextGenerationPipeline<M> {
         let eos_tokens = self.base.model.lock().unwrap().get_eos_tokens();
         let tokenizer = self.base.model_tokenizer.clone();
         let context = Arc::clone(&self.base.context);
-        let params = self.base.gen_params.clone();
+        let params = self.base.gen_params.lock().unwrap().clone();
 
         Box::pin(try_stream! {
             const CHUNK_SIZE: usize = 64;

--- a/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
@@ -39,6 +39,10 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
         self.base.context_position()
     }
 
+    pub fn set_generation_params(&self, params: GenerationParams) {
+        self.base.set_generation_params(params);
+    }
+
     /// Get a reference to the XML parser
     pub fn xml_parser(&self) -> &XmlParser {
         &self.xml_parser
@@ -273,7 +277,7 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
         let eos_tokens = self.base.model.lock().unwrap().get_eos_tokens();
         let tokenizer = self.base.model_tokenizer.clone();
         let context = Arc::clone(&self.base.context);
-        let params = self.base.gen_params.clone();
+        let params = self.base.gen_params.lock().unwrap().clone();
 
         Box::pin(try_stream! {
             const CHUNK_SIZE: usize = 64;

--- a/tests/text_generation_pipeline_tests/basic_text_generation.rs
+++ b/tests/text_generation_pipeline_tests/basic_text_generation.rs
@@ -41,3 +41,21 @@ fn test_empty_input_handling() -> anyhow::Result<()> {
     assert!(!out.trim().is_empty());
     Ok(())
 }
+
+#[test]
+fn test_set_generation_params() -> anyhow::Result<()> {
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(42)
+        .max_len(1)
+        .build()?;
+
+    let short = pipeline.completion("Rust is a")?;
+
+    let new_params = GenerationParams::new(0.7, 1.0, 64, 42, 8, 1.0, 0, 0.0);
+    pipeline.set_generation_params(new_params);
+
+    let longer = pipeline.completion("Rust is a")?;
+
+    assert!(longer.len() >= short.len());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `set_generation_params` on `BasePipeline`
- expose it through text and XML generation pipelines
- re-export `GenerationParams`
- test that changing generation parameters alters output

## Testing
- `cargo test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68688a4cf84c83308f77863962fd8597