### PR TITLE
Add device customization and tool management

### DIFF
--- a/src/models/quantized_qwen3.rs
+++ b/src/models/quantized_qwen3.rs
@@ -963,6 +963,18 @@ impl ToolCalling for Qwen3Model {
         Ok(())
     }
 
+    fn unregister_tool(&mut self, name: &str) -> anyhow::Result<()> {
+        if let Some(pos) = self.tools.iter().position(|t| t.name() == name) {
+            self.tools.remove(pos);
+        }
+        Ok(())
+    }
+
+    fn clear_tools(&mut self) -> anyhow::Result<()> {
+        self.tools.clear();
+        Ok(())
+    }
+
     fn registered_tools(&self) -> Vec<Tool> {
         self.tools.clone()
     }

--- a/src/pipelines/text_generation_pipeline/base_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/base_pipeline.rs
@@ -3,7 +3,6 @@ use super::text_generation_model::TextGenerationModel;
 use crate::models::generation::{
     apply_repeat_penalty, initialize_logits_processor, GenerationParams,
 };
-use crate::pipelines::utils::load_device;
 use candle_core::Tensor;
 use std::sync::{Arc, Mutex};
 use tokenizers::Tokenizer;
@@ -20,10 +19,13 @@ pub struct BasePipeline<M: TextGenerationModel> {
 }
 
 impl<M: TextGenerationModel> BasePipeline<M> {
-    pub fn new(model: M, gen_params: GenerationParams) -> anyhow::Result<Self> {
+    pub fn new(
+        model: M,
+        gen_params: GenerationParams,
+        device: candle_core::Device,
+    ) -> anyhow::Result<Self> {
         let model_tokenizer = model.get_tokenizer()?;
         let context = model.new_context();
-        let device = load_device()?;
 
         // Collect textual forms of special tokens for display filtering
         let mut special_strings: std::collections::HashSet<String> = model_tokenizer

--- a/src/pipelines/text_generation_pipeline/text_generation_model.rs
+++ b/src/pipelines/text_generation_pipeline/text_generation_model.rs
@@ -88,6 +88,8 @@ pub trait ToggleableReasoning {
 
 pub trait ToolCalling {
     fn register_tool(&mut self, tool: Tool) -> anyhow::Result<()>;
+    fn unregister_tool(&mut self, name: &str) -> anyhow::Result<()>;
+    fn clear_tools(&mut self) -> anyhow::Result<()>;
     fn registered_tools(&self) -> Vec<Tool>;
     fn call_tool(
         &mut self,

--- a/src/pipelines/text_generation_pipeline/text_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/text_generation_pipeline.rs
@@ -50,9 +50,13 @@ pub struct TextGenerationPipeline<M: TextGenerationModel> {
 }
 
 impl<M: TextGenerationModel> TextGenerationPipeline<M> {
-    pub fn new(model: M, gen_params: GenerationParams) -> anyhow::Result<Self> {
+    pub fn new(
+        model: M,
+        gen_params: GenerationParams,
+        device: candle_core::Device,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
-            base: BasePipeline::new(model, gen_params)?,
+            base: BasePipeline::new(model, gen_params, device)?,
         })
     }
 
@@ -339,6 +343,14 @@ impl<M: TextGenerationModel + ToolCalling + Send> TextGenerationPipeline<M> {
     pub fn register_tool<T: IntoTool>(&self, tool: T) -> anyhow::Result<()> {
         let tool = tool.into_tool();
         self.base.model.lock().unwrap().register_tool(tool)
+    }
+
+    pub fn unregister_tool(&self, name: &str) -> anyhow::Result<()> {
+        self.base.model.lock().unwrap().unregister_tool(name)
+    }
+
+    pub fn clear_tools(&self) -> anyhow::Result<()> {
+        self.base.model.lock().unwrap().clear_tools()
     }
 
     pub fn register_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {

--- a/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
@@ -27,9 +27,10 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
         model: M,
         gen_params: GenerationParams,
         xml_parser: XmlParser,
+        device: candle_core::Device,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            base: BasePipeline::new(model, gen_params)?,
+            base: BasePipeline::new(model, gen_params, device)?,
             xml_parser,
         })
     }
@@ -367,6 +368,14 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
     pub fn register_tool<T: IntoTool>(&self, tool: T) -> anyhow::Result<()> {
         let tool = tool.into_tool();
         self.base.model.lock().unwrap().register_tool(tool)
+    }
+
+    pub fn unregister_tool(&self, name: &str) -> anyhow::Result<()> {
+        self.base.model.lock().unwrap().unregister_tool(name)
+    }
+
+    pub fn clear_tools(&self) -> anyhow::Result<()> {
+        self.base.model.lock().unwrap().clear_tools()
     }
 
     pub fn register_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {

--- a/src/pipelines/utils/mod.rs
+++ b/src/pipelines/utils/mod.rs
@@ -2,10 +2,24 @@ use candle_core::{CudaDevice, Device};
 
 pub mod model_cache;
 
-/// Loads a device to be used for the model. Uses CUDA by default, falling back to CPU if CUDA is not available.
-pub fn load_device() -> anyhow::Result<Device> {
-    match CudaDevice::new_with_stream(0) {
-        Ok(cuda_device) => Ok(Device::Cuda(cuda_device)),
-        Err(_) => Ok(Device::Cpu),
+/// Loads a device to be used for the model.
+/// If `index` is `Some(i)` it will attempt to load the specified CUDA device.
+/// When `None` it defaults to CUDA device 0 if available and otherwise falls back
+/// to CPU.
+pub fn load_device_with(index: Option<usize>) -> anyhow::Result<Device> {
+    if let Some(i) = index {
+        let cuda = CudaDevice::new_with_stream(i)?;
+        Ok(Device::Cuda(cuda))
+    } else {
+        match CudaDevice::new_with_stream(0) {
+            Ok(cuda_device) => Ok(Device::Cuda(cuda_device)),
+            Err(_) => Ok(Device::Cpu),
+        }
     }
+}
+
+/// Convenience wrapper that preserves the previous behaviour of selecting CUDA 0
+/// if available and otherwise falling back to CPU.
+pub fn load_device() -> anyhow::Result<Device> {
+    load_device_with(None)
 }

--- a/tests/misc_pipeline_tests/tool_management.rs
+++ b/tests/misc_pipeline_tests/tool_management.rs
@@ -1,0 +1,27 @@
+use transformers::pipelines::text_generation_pipeline::*;
+
+#[tool]
+fn echo(msg: String) -> String {
+    msg
+}
+
+#[test]
+fn unregister_and_clear() -> anyhow::Result<()> {
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .seed(0)
+        .max_len(20)
+        .build()?;
+
+    pipeline.register_tools(tools![echo])?;
+    assert_eq!(pipeline.registered_tools().len(), 1);
+
+    pipeline.unregister_tool("echo")?;
+    assert!(pipeline.registered_tools().is_empty());
+
+    pipeline.register_tool(echo)?;
+    assert_eq!(pipeline.registered_tools().len(), 1);
+
+    pipeline.clear_tools()?;
+    assert!(pipeline.registered_tools().is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- allow explicit device selection with optional CUDA index
- support unregistering and clearing tools from pipelines
- test tool management functionality

## Testing
- `cargo test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68688502cf108330ac1731fed2aadeeb