### PR TITLE
Refactor Event API

### DIFF
--- a/examples/xml_parser.rs
+++ b/examples/xml_parser.rs
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
+            Some(_) => { /* ignore unknown tags */ }
             None => match event.part() {
                 TagParts::Start => println!("[OUTPUT]"),
                 TagParts::Content => print!("{}", event.get_content()),

--- a/examples/xml_parser.rs
+++ b/examples/xml_parser.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
-            _ => match event.part() {
+            None => match event.part() {
                 TagParts::Start => println!("[OUTPUT]"),
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END OUTPUT]\n"),

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
-            _ => match event.part() {
+            None => match event.part() {
                 TagParts::Start => println!("[OUTPUT]"),
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END OUTPUT]\n"),

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<()> {
                 TagParts::Content => print!("{}", event.get_content()),
                 TagParts::End => println!("[END TOOL CALL]\n"),
             },
+            Some(_) => { /* ignore unknown tags */ }
             None => match event.part() {
                 TagParts::Start => println!("[OUTPUT]"),
                 TagParts::Content => print!("{}", event.get_content()),


### PR DESCRIPTION
## Summary
- redesign XML `Event` representation into enum variants
- update examples to use classic `tag()` matching pattern

## Testing
- `cargo test --lib`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6868b303b98c8330a46e0cb2cf06f9c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved clarity and reliability of XML parsing by explicitly distinguishing between tagged and untagged events.
  * Enhanced event handling logic to better differentiate cases where tags are absent.

* **Bug Fixes**
  * Adjusted control flow to ensure only absent tags are handled as default cases, reducing potential for unintended matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->