### PR TITLE
Make completion APIs async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ aho-corasick = "1.1.3"
 candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.1" }
 candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.1" }
 hf-hub = "0.4.3"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }

--- a/examples/fill_mask.rs
+++ b/examples/fill_mask.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 use transformers::pipelines::fill_mask_pipeline::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     println!("Building pipeline...");
 
-    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base)
+        .build()
+        .await?;
 
     println!("Pipeline built successfully.");
 

--- a/examples/sentiment_analysis.rs
+++ b/examples/sentiment_analysis.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 use transformers::pipelines::sentiment_analysis_pipeline::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     println!("Building pipeline...");
 
-    let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+    let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base)
+        .build()
+        .await?;
 
     println!("Pipeline built successfully.");
 

--- a/examples/text_generation.rs
+++ b/examples/text_generation.rs
@@ -1,17 +1,21 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // Start by creating the pipeline, using the builder to configure any generation parameters.
     // Parameters are optional, defaults are set to good values for each model.
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .temperature(0.7)
         .top_k(40)
         .max_len(1024)
-        .build()?;
+        .build()
+        .await?;
 
     // Get a completion from a prompt.
-    let completion = pipeline.completion("Explain the concept of Large Language Models in simple terms.")?;
+    let completion = pipeline
+        .completion("Explain the concept of Large Language Models in simple terms.")
+        .await?;
 
     println!("\n--- Generated Text ---");
     println!("{}", completion);
@@ -22,7 +26,7 @@ fn main() -> Result<()> {
         Message::user("What is the capital of France?"),
     ];
 
-    let completion = pipeline.completion(&messages)?;
+    let completion = pipeline.completion(&messages).await?;
 
     println!("\n--- Generated Text 2 ---");
     println!("{}", completion);
@@ -32,7 +36,7 @@ fn main() -> Result<()> {
     messages.push(Message::user("What are some fun things to do there?"));
 
     // Now ask a follow-up question.
-    let completion = pipeline.completion(&messages)?;
+    let completion = pipeline.completion(&messages).await?;
 
     println!("\n--- Generated Text 3 (Follow-up) ---");
     println!("{}", completion);

--- a/examples/text_generation_streaming.rs
+++ b/examples/text_generation_streaming.rs
@@ -6,11 +6,14 @@ async fn main() -> Result<()> {
     // Start by creating the pipeline, using the builder to configure any generation parameters.
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(1024)
-        .build()?;
+        .build()
+        .await?;
 
-    let mut stream = pipeline.completion_stream(
+    let mut stream = pipeline
+        .completion_stream(
         "Explain the concept of Large Language Models in simple terms.",
-    )?;
+    )
+    .await?;
 
     println!("\n--- Generated Text ---");
     while let Some(tok) = stream.next().await {
@@ -24,7 +27,7 @@ async fn main() -> Result<()> {
         Message::user("What is the capital of France?"),
     ];
 
-    let mut stream_two = pipeline.completion_stream(&messages)?;
+    let mut stream_two = pipeline.completion_stream(&messages).await?;
 
     println!("\n--- Generated Text 2 ---");
     while let Some(tok) = stream_two.next().await {

--- a/examples/text_generation_tools.rs
+++ b/examples/text_generation_tools.rs
@@ -27,14 +27,17 @@ async fn main() -> Result<()> {
 
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(8192)
-        .build()?;
+        .build()
+        .await?;
 
     println!("Pipeline built successfully.");
 
-    pipeline.register_tools(tools![get_temperature, get_humidity])?;
+    pipeline.register_tools(tools![get_temperature, get_humidity]).await?;
 
     let mut stream =
-        pipeline.completion_stream_with_tools("What's the temp and humidity like in Tokyo?")?;
+        pipeline
+            .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
+            .await?;
 
     println!("Generating text 1...");
 
@@ -43,10 +46,12 @@ async fn main() -> Result<()> {
         std::io::stdout().flush().unwrap();
     }
 
-    pipeline.unregister_tools(tools![get_temperature])?;
+    pipeline.unregister_tools(tools![get_temperature]).await?;
 
     let mut stream =
-        pipeline.completion_stream_with_tools("What's the temp and humidity like in Tokyo?")?;
+        pipeline
+            .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
+            .await?;
 
     println!("Generating text 2...");
 

--- a/examples/xml_parser.rs
+++ b/examples/xml_parser.rs
@@ -7,16 +7,19 @@ fn get_weather(city: String) -> Result<String, ToolError> {
     Ok(format!("The weather in {} is sunny.", city))
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     // Build a pipeline with XML parsing capabilities
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(1024)
-        .build_xml(&["think", "tool_result", "tool_call"])?;
-
-    pipeline.register_tools(tools![get_weather])?;
+        .build_xml(&["think", "tool_result", "tool_call"])
+        .await?;
+    pipeline.register_tools(tools![get_weather]).await?;
 
     // Generate completion - this will return Vec<Event>
-    let events = pipeline.completion_with_tools("What's the weather like in Tokyo?")?;
+    let events = pipeline
+        .completion_with_tools("What's the weather like in Tokyo?")
+        .await?;
 
     println!("\n--- Generated Events ---");
     for event in events {

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -24,12 +24,15 @@ async fn main() -> Result<()> {
     // Build a pipeline with XML parsing capabilities
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .max_len(1024)
-        .build_xml(&["think", "tool_result", "tool_call"])?;
+        .build_xml(&["think", "tool_result", "tool_call"])
+        .await?;
 
-    pipeline.register_tools(tools![get_weather])?;
+    pipeline.register_tools(tools![get_weather]).await?;
 
     // Stream completion - this will yield Event items
-    let mut stream = pipeline.completion_stream_with_tools("What's the weather like in Tokyo?")?;
+    let mut stream = pipeline
+        .completion_stream_with_tools("What's the weather like in Tokyo?")
+        .await?;
 
     println!("\n--- Streaming Events ---");
 

--- a/examples/zero_shot.rs
+++ b/examples/zero_shot.rs
@@ -1,11 +1,14 @@
 use anyhow::Result;
 use transformers::pipelines::zero_shot_classification_pipeline::*;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     println!("Building pipeline...");
 
     let pipeline =
-        ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+        ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base)
+            .build()
+            .await?;
 
     println!("Pipeline built successfully.\n");
 

--- a/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
+++ b/src/pipelines/fill_mask_pipeline/fill_mask_pipeline_builder.rs
@@ -32,7 +32,7 @@ impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
         self
     }
 
-    pub fn build(self) -> anyhow::Result<FillMaskPipeline<M>>
+    pub async fn build(self) -> anyhow::Result<FillMaskPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
@@ -42,7 +42,9 @@ impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
             None => crate::pipelines::utils::load_device()?,
         };
         let key = format!("{}-{:?}", self.options.cache_key(), device.location());
-        let model = global_cache().get_or_create(&key, || M::new(self.options.clone(), device.clone()))?;
+        let model = global_cache()
+            .get_or_create(&key, || M::new(self.options.clone(), device.clone()))
+            .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(FillMaskPipeline { model, tokenizer })
     }

--- a/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/sentiment_analysis_pipeline_builder.rs
@@ -32,7 +32,7 @@ impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
         self
     }
 
-    pub fn build(self) -> anyhow::Result<SentimentAnalysisPipeline<M>>
+    pub async fn build(self) -> anyhow::Result<SentimentAnalysisPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
@@ -42,7 +42,9 @@ impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
             None => crate::pipelines::utils::load_device()?,
         };
         let key = format!("{}-{:?}", self.options.cache_key(), device.location());
-        let model = global_cache().get_or_create(&key, || M::new(self.options.clone(), device.clone()))?;
+        let model = global_cache()
+            .get_or_create(&key, || M::new(self.options.clone(), device.clone()))
+            .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(SentimentAnalysisPipeline { model, tokenizer })
     }

--- a/src/pipelines/text_generation_pipeline/text_generation_pipeline_builder.rs
+++ b/src/pipelines/text_generation_pipeline/text_generation_pipeline_builder.rs
@@ -103,14 +103,16 @@ impl<M: TextGenerationModel> TextGenerationPipelineBuilder<M> {
         self
     }
 
-    pub fn build(self) -> anyhow::Result<TextGenerationPipeline<M>>
+    pub async fn build(self) -> anyhow::Result<TextGenerationPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
     {
         // Always use the global cache to share models
         let cache_key = self.model_options.cache_key();
-        let model = global_cache().get_or_create(&cache_key, || Ok(M::new(self.model_options.clone())))?;
+        let model = global_cache()
+            .get_or_create(&cache_key, || Ok(M::new(self.model_options.clone())))
+            .await?;
 
         // Start with model-specific defaults
         let default_params = model.default_generation_params();
@@ -136,14 +138,16 @@ impl<M: TextGenerationModel> TextGenerationPipelineBuilder<M> {
         TextGenerationPipeline::new(model, gen_params, device)
     }
 
-    pub fn build_xml(self, tags: &[&str]) -> anyhow::Result<XmlGenerationPipeline<M>>
+    pub async fn build_xml(self, tags: &[&str]) -> anyhow::Result<XmlGenerationPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
     {
         // Always use the global cache to share models
         let cache_key = self.model_options.cache_key();
-        let model = global_cache().get_or_create(&cache_key, || Ok(M::new(self.model_options.clone())))?;
+        let model = global_cache()
+            .get_or_create(&cache_key, || Ok(M::new(self.model_options.clone())))
+            .await?;
 
         // Start with model-specific defaults
         let default_params = model.default_generation_params();

--- a/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
@@ -22,7 +22,7 @@ pub struct XmlGenerationPipeline<M: TextGenerationModel> {
     xml_parser: XmlParser,
 }
 
-impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
+impl<M: TextGenerationModel + Send> XmlGenerationPipeline<M> {
     pub fn new(
         model: M,
         gen_params: GenerationParams,
@@ -36,12 +36,12 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
     }
 
     /// Get the current position in the context (number of cached tokens)
-    pub fn context_position(&self) -> usize {
-        self.base.context_position()
+    pub async fn context_position(&self) -> usize {
+        self.base.context_position().await
     }
 
-    pub fn set_generation_params(&self, params: GenerationParams) {
-        self.base.set_generation_params(params);
+    pub async fn set_generation_params(&self, params: GenerationParams) {
+        self.base.set_generation_params(params).await;
     }
 
     /// Get a reference to the XML parser
@@ -51,24 +51,24 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
 
     /// Generate a completion from either a prompt or a chat history.
     /// Returns a Vec<Event>.
-    pub fn completion<'a>(&self, input: impl Into<Input<'a>>) -> anyhow::Result<Vec<Event>> {
+    pub async fn completion<'a>(&self, input: impl Into<Input<'a>>) -> anyhow::Result<Vec<Event>> {
         let text = match input.into() {
-            Input::Prompt(p) => self.prompt_completion_internal(p)?,
-            Input::Messages(m) => self.message_completion_internal(m)?,
+            Input::Prompt(p) => self.prompt_completion_internal(p).await?,
+            Input::Messages(m) => self.message_completion_internal(m).await?,
         };
 
         Ok(self.xml_parser.parse_complete(&text))
     }
 
-    fn prompt_completion_internal(&self, prompt: &str) -> anyhow::Result<String> {
+    async fn prompt_completion_internal(&self, prompt: &str) -> anyhow::Result<String> {
         // Reset context for fresh generation
-        self.base.context.lock().unwrap().reset();
+        self.base.context.lock().await.reset();
 
         let templated_prompt = self
             .base
             .model
             .lock()
-            .unwrap()
+            .await
             .apply_chat_template(&[crate::Message::user(prompt)])?;
 
         let prompt_tokens = self
@@ -79,15 +79,15 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
             .get_ids()
             .to_vec();
 
-        self.base.completion_from_tokens(&prompt_tokens)
+        self.base.completion_from_tokens(&prompt_tokens).await
     }
 
-    fn message_completion_internal(&self, messages: &[crate::Message]) -> anyhow::Result<String> {
+    async fn message_completion_internal(&self, messages: &[crate::Message]) -> anyhow::Result<String> {
         let templated_prompt = self
             .base
             .model
             .lock()
-            .unwrap()
+            .await
             .apply_chat_template(messages)?;
 
         let new_tokens = self
@@ -99,59 +99,59 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
             .to_vec();
 
         // Check if we need to reset due to context overflow
-        let max_seq_len = self.base.model.lock().unwrap().get_max_seq_len();
+        let max_seq_len = self.base.model.lock().await.get_max_seq_len();
         let pending_tokens = new_tokens.len();
 
-        if self.base.context.lock().unwrap().position() + pending_tokens > max_seq_len {
+        if self.base.context.lock().await.position() + pending_tokens > max_seq_len {
             // Context would overflow, reset and start fresh
-            self.base.context.lock().unwrap().reset();
-            self.base.last_processed_tokens.lock().unwrap().clear();
-        } else if self.base.can_reuse_cache(&new_tokens) {
+            self.base.context.lock().await.reset();
+            self.base.last_processed_tokens.lock().await.clear();
+        } else if self.base.can_reuse_cache(&new_tokens).await {
             // Cache prefix matches, only feed the suffix
-            let prefix_len = self.base.last_processed_tokens.lock().unwrap().len();
+            let prefix_len = self.base.last_processed_tokens.lock().await.len();
             let new_portion = &new_tokens[prefix_len..];
-            let response = self.base.completion_from_tokens(new_portion)?;
+            let response = self.base.completion_from_tokens(new_portion).await?;
 
             // Track only prompt tokens for next turn
-            *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+            *self.base.last_processed_tokens.lock().await = new_tokens;
             return Ok(response);
         } else {
             // Cache is invalid (conversation changed), reset
-            self.base.context.lock().unwrap().reset();
+            self.base.context.lock().await.reset();
         }
 
         // Process all tokens from scratch
-        let response = self.base.completion_from_tokens(&new_tokens)?;
+        let response = self.base.completion_from_tokens(&new_tokens).await?;
 
         // Update tracking (prompt tokens only)
-        *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+        *self.base.last_processed_tokens.lock().await = new_tokens;
 
         Ok(response)
     }
 
     /// Streaming version of completion that yields Events
-    pub fn completion_stream<'a>(
+    pub async fn completion_stream<'a>(
         &'a self,
         input: impl Into<Input<'a>>,
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + 'a>>> {
         match input.into() {
-            Input::Prompt(p) => self.prompt_completion_stream(p),
-            Input::Messages(m) => self.message_completion_stream(m),
+            Input::Prompt(p) => self.prompt_completion_stream(p).await,
+            Input::Messages(m) => self.message_completion_stream(m).await,
         }
     }
 
-    fn prompt_completion_stream(
+    async fn prompt_completion_stream(
         &self,
         prompt: &str,
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + '_>>> {
         // Fresh turn → reset context
-        self.base.context.lock().unwrap().reset();
+        self.base.context.lock().await.reset();
 
         let templated = self
             .base
             .model
             .lock()
-            .unwrap()
+            .await
             .apply_chat_template(&[crate::Message::user(prompt)])?;
         let tokens = self
             .base
@@ -186,7 +186,7 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
         }))
     }
 
-    fn message_completion_stream(
+    async fn message_completion_stream(
         &self,
         messages: &[crate::Message],
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + '_>>> {
@@ -194,7 +194,7 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
             .base
             .model
             .lock()
-            .unwrap()
+            .await
             .apply_chat_template(messages)?;
         let new_tokens = self
             .base
@@ -205,14 +205,14 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
             .to_vec();
 
         // Same cache logic
-        let max_seq = self.base.model.lock().unwrap().get_max_seq_len();
-        if self.base.context.lock().unwrap().position() + new_tokens.len() > max_seq {
-            self.base.context.lock().unwrap().reset();
-            self.base.last_processed_tokens.lock().unwrap().clear();
-        } else if self.base.can_reuse_cache(&new_tokens) {
+        let max_seq = self.base.model.lock().await.get_max_seq_len();
+        if self.base.context.lock().await.position() + new_tokens.len() > max_seq {
+            self.base.context.lock().await.reset();
+            self.base.last_processed_tokens.lock().await.clear();
+        } else if self.base.can_reuse_cache(&new_tokens).await {
             let suffix =
-                new_tokens[self.base.last_processed_tokens.lock().unwrap().len()..].to_vec();
-            *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+                new_tokens[self.base.last_processed_tokens.lock().await.len()..].to_vec();
+            *self.base.last_processed_tokens.lock().await = new_tokens;
 
             let inner = self.raw_completion_stream(suffix);
             self.xml_parser.reset();
@@ -237,10 +237,10 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
                 }
             }));
         } else {
-            self.base.context.lock().unwrap().reset();
+            self.base.context.lock().await.reset();
         }
 
-        *self.base.last_processed_tokens.lock().unwrap() = new_tokens.clone();
+        *self.base.last_processed_tokens.lock().await = new_tokens.clone();
         let inner = self.raw_completion_stream(new_tokens);
 
         self.xml_parser.reset();
@@ -275,12 +275,14 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
     {
         // Capture everything the async generator needs **by value**
         let device = self.base.device.clone();
-        let eos_tokens = self.base.model.lock().unwrap().get_eos_tokens();
+        let model = Arc::clone(&self.base.model);
         let tokenizer = self.base.model_tokenizer.clone();
         let context = Arc::clone(&self.base.context);
-        let params = self.base.gen_params.lock().unwrap().clone();
+        let gen_params = Arc::clone(&self.base.gen_params);
 
         Box::pin(try_stream! {
+            let params = gen_params.lock().await.clone();
+            let eos_tokens = model.lock().await.get_eos_tokens();
             const CHUNK_SIZE: usize = 64;
 
             let mut logits_processor =
@@ -295,7 +297,7 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
 
                 let input  = Tensor::new(chunk, &device)?.unsqueeze(0)?;
                 let logits = {
-                    let mut ctx = context.lock().unwrap();
+                    let mut ctx = context.lock().await;
                     ctx.generate(&input)
                 }?;
                 last_logits = Some(logits.squeeze(0)?);
@@ -329,7 +331,7 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
 
                 let input  = Tensor::new(&[next_token], &device)?.unsqueeze(0)?;
                 let logits = {
-                    let mut ctx = context.lock().unwrap();
+                    let mut ctx = context.lock().await;
                     ctx.generate(&input)
                 }?;
                 let logits = logits.squeeze(0)?;
@@ -362,41 +364,41 @@ impl<M: TextGenerationModel> XmlGenerationPipeline<M> {
 
 // Implementations for models with ToggleableReasoning
 impl<M: TextGenerationModel + ToggleableReasoning> XmlGenerationPipeline<M> {
-    pub fn set_reasoning(&self, enable: bool) -> anyhow::Result<()> {
-        self.base.model.lock().unwrap().set_reasoning(enable)
+    pub async fn set_reasoning(&self, enable: bool) -> anyhow::Result<()> {
+        self.base.model.lock().await.set_reasoning(enable)
     }
 }
 
 // Implementations for models with ToolCalling
 impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
-    pub fn unregister_tool(&self, name: &str) -> anyhow::Result<()> {
-        self.base.model.lock().unwrap().unregister_tool(name)
+    pub async fn unregister_tool(&self, name: &str) -> anyhow::Result<()> {
+        self.base.model.lock().await.unregister_tool(name)
     }
 
-    pub fn clear_tools(&self) -> anyhow::Result<()> {
-        self.base.model.lock().unwrap().clear_tools()
+    pub async fn clear_tools(&self) -> anyhow::Result<()> {
+        self.base.model.lock().await.clear_tools()
     }
 
-    pub fn register_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {
+    pub async fn register_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {
         for tool in tools {
-            self.base.model.lock().unwrap().register_tool(tool)?;
+            self.base.model.lock().await.register_tool(tool)?;
         }
         Ok(())
     }
 
-    pub fn unregister_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {
+    pub async fn unregister_tools(&self, tools: Vec<Tool>) -> anyhow::Result<()> {
         for tool in tools {
             self.base
                 .model
                 .lock()
-                .unwrap()
+                .await
                 .unregister_tool(&tool.name)?;
         }
         Ok(())
     }
 
-    pub fn registered_tools(&self) -> Vec<Tool> {
-        self.base.model.lock().unwrap().registered_tools()
+    pub async fn registered_tools(&self) -> Vec<Tool> {
+        self.base.model.lock().await.registered_tools()
     }
 
     /// Execute a list of tool calls with retry logic and error handling
@@ -457,11 +459,11 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
         Ok(tool_responses)
     }
 
-    pub fn completion_with_tools<'a>(
+    pub async fn completion_with_tools<'a>(
         &self,
         input: impl Into<Input<'a>>,
     ) -> anyhow::Result<Vec<Event>> {
-        let tools = self.base.model.lock().unwrap().registered_tools();
+        let tools = self.base.model.lock().await.registered_tools();
         if tools.is_empty() {
             anyhow::bail!("No tools registered. Call register_tools() first.");
         }
@@ -479,7 +481,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                 .base
                 .model
                 .lock()
-                .unwrap()
+                .await
                 .apply_chat_template(&messages)?;
             let new_tokens = self
                 .base
@@ -490,24 +492,24 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                 .to_vec();
 
             // Check if we need to reset due to context overflow
-            let max_seq_len = self.base.model.lock().unwrap().get_max_seq_len();
+            let max_seq_len = self.base.model.lock().await.get_max_seq_len();
             let pending_tokens = new_tokens.len();
 
             let response =
-                if self.base.context.lock().unwrap().position() + pending_tokens > max_seq_len {
-                    self.base.context.lock().unwrap().reset();
-                    self.base.last_processed_tokens.lock().unwrap().clear();
-                    self.base.completion_from_tokens(&new_tokens)?
-                } else if self.base.can_reuse_cache(&new_tokens) {
-                    let prefix_len = self.base.last_processed_tokens.lock().unwrap().len();
+                if self.base.context.lock().await.position() + pending_tokens > max_seq_len {
+                    self.base.context.lock().await.reset();
+                    self.base.last_processed_tokens.lock().await.clear();
+                    self.base.completion_from_tokens(&new_tokens).await?
+                } else if self.base.can_reuse_cache(&new_tokens).await {
+                    let prefix_len = self.base.last_processed_tokens.lock().await.len();
                     let new_portion = &new_tokens[prefix_len..];
-                    let res = self.base.completion_from_tokens(new_portion)?;
-                    *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+                    let res = self.base.completion_from_tokens(new_portion).await?;
+                    *self.base.last_processed_tokens.lock().await = new_tokens;
                     res
                 } else {
-                    self.base.context.lock().unwrap().reset();
-                    let res = self.base.completion_from_tokens(&new_tokens)?;
-                    *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+                    self.base.context.lock().await.reset();
+                    let res = self.base.completion_from_tokens(&new_tokens).await?;
+                    *self.base.last_processed_tokens.lock().await = new_tokens;
                     res
                 };
 
@@ -545,14 +547,14 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
         }
     }
 
-    pub fn completion_stream_with_tools<'a>(
+    pub async fn completion_stream_with_tools<'a>(
         &'a self,
         input: impl Into<Input<'a>>,
     ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + 'a>>> {
         use async_stream::stream;
         use futures::StreamExt;
 
-        let tools = self.base.model.lock().unwrap().registered_tools();
+        let tools = self.base.model.lock().await.registered_tools();
         if tools.is_empty() {
             anyhow::bail!("No tools registered. Call register_tools() first.");
         }
@@ -576,7 +578,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                         .base
                         .model
                         .lock()
-                        .unwrap()
+                        .await
                         .apply_chat_template(&messages)
                         .expect("failed to apply chat template");
                     let new_tokens = self
@@ -589,21 +591,21 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                         .to_vec();
 
                     // Handle context overflow and caching
-                    let max_seq_len = self.base.model.lock().unwrap().get_max_seq_len();
+                    let max_seq_len = self.base.model.lock().await.get_max_seq_len();
                     let pending_tokens = new_tokens.len();
 
-                    let tokens_to_process = if self.base.context.lock().unwrap().position() + pending_tokens > max_seq_len {
-                        self.base.context.lock().unwrap().reset();
-                        self.base.last_processed_tokens.lock().unwrap().clear();
+                    let tokens_to_process = if self.base.context.lock().await.position() + pending_tokens > max_seq_len {
+                        self.base.context.lock().await.reset();
+                        self.base.last_processed_tokens.lock().await.clear();
                         new_tokens.clone()
-                    } else if self.base.can_reuse_cache(&new_tokens) {
-                        let prefix_len = self.base.last_processed_tokens.lock().unwrap().len();
+                    } else if self.base.can_reuse_cache(&new_tokens).await {
+                        let prefix_len = self.base.last_processed_tokens.lock().await.len();
                         let suffix = new_tokens[prefix_len..].to_vec();
-                        *self.base.last_processed_tokens.lock().unwrap() = new_tokens;
+                        *self.base.last_processed_tokens.lock().await = new_tokens;
                         suffix
                     } else {
-                        self.base.context.lock().unwrap().reset();
-                        *self.base.last_processed_tokens.lock().unwrap() = new_tokens.clone();
+                        self.base.context.lock().await.reset();
+                        *self.base.last_processed_tokens.lock().await = new_tokens.clone();
                         new_tokens
                     };
 

--- a/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/zero_shot_classification_pipeline_builder.rs
@@ -32,7 +32,7 @@ impl<M: ZeroShotClassificationModel> ZeroShotClassificationPipelineBuilder<M> {
         self
     }
 
-    pub fn build(self) -> anyhow::Result<ZeroShotClassificationPipeline<M>>
+    pub async fn build(self) -> anyhow::Result<ZeroShotClassificationPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
@@ -42,7 +42,9 @@ impl<M: ZeroShotClassificationModel> ZeroShotClassificationPipelineBuilder<M> {
             None => crate::pipelines::utils::load_device()?,
         };
         let key = format!("{}-{:?}", self.options.cache_key(), device.location());
-        let model = global_cache().get_or_create(&key, || M::new(self.options.clone(), device.clone()))?;
+        let model = global_cache()
+            .get_or_create(&key, || M::new(self.options.clone(), device.clone()))
+            .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(ZeroShotClassificationPipeline { model, tokenizer })
     }

--- a/tests/fill_mask_pipeline_tests/basic_fill_mask.rs
+++ b/tests/fill_mask_pipeline_tests/basic_fill_mask.rs
@@ -4,35 +4,41 @@
 use transformers::pipelines::fill_mask_pipeline::*;
 use candle_core::DeviceLocation;
 
-#[test]
-fn basic_fill_mask() -> anyhow::Result<()> {
-    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+#[tokio::test]
+async fn basic_fill_mask() -> anyhow::Result<()> {
+    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base)
+        .build()
+        .await?;
     let res = pipeline.fill_mask("The capital of France is [MASK].")?;
     assert!(res.contains("Paris") || !res.trim().is_empty());
     Ok(())
 }
 
-#[test]
-fn test_empty_input_handling() -> anyhow::Result<()> {
-    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+#[tokio::test]
+async fn test_empty_input_handling() -> anyhow::Result<()> {
+    let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base)
+        .build()
+        .await?;
     assert!(pipeline.fill_mask("").is_err());
     Ok(())
 }
 
-#[test]
-fn select_cpu_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cpu_device() -> anyhow::Result<()> {
     let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base)
         .cpu()
-        .build()?;
+        .build()
+        .await?;
     assert!(pipeline.device().is_cpu());
     Ok(())
 }
 
-#[test]
-fn select_cuda_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cuda_device() -> anyhow::Result<()> {
     let pipeline = FillMaskPipelineBuilder::modernbert(ModernBertSize::Base)
         .cuda_device(0)
-        .build()?;
+        .build()
+        .await?;
     match pipeline.device().location() {
         DeviceLocation::Cuda { gpu_id } => assert_eq!(gpu_id, 0),
         _ => {}

--- a/tests/misc_pipeline_tests/multi_pipeline.rs
+++ b/tests/misc_pipeline_tests/multi_pipeline.rs
@@ -4,25 +4,26 @@
 use transformers::pipelines::global_cache;
 use transformers::pipelines::text_generation_pipeline::*;
 
-#[test]
-fn multiple_pipelines_share_weights_and_have_independent_caches() -> anyhow::Result<()> {
+#[tokio::test]
+async fn multiple_pipelines_share_weights_and_have_independent_caches() -> anyhow::Result<()> {
     // Ensure the cache is clean so we can accurately count models
-    global_cache().clear();
+    global_cache().clear().await;
 
     let mut pipelines = Vec::new();
     for _ in 0..10 {
         let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
             .temperature(0.7)
             .max_len(10)
-            .build()?;
+            .build()
+            .await?;
         pipelines.push(pipeline);
     }
 
     // Only one model should be loaded
-    assert_eq!(global_cache().len(), 1);
+    assert_eq!(global_cache().len().await, 1);
 
     let prompt = "Hello, world!";
-    let _ = pipelines[0].completion(prompt)?;
+    let _ = pipelines[0].completion(prompt).await?;
 
     // The first pipeline should have advanced its context
     assert!(pipelines[0].context_position() > 0);
@@ -30,7 +31,7 @@ fn multiple_pipelines_share_weights_and_have_independent_caches() -> anyhow::Res
     // Other pipelines should remain untouched
     for (idx, p) in pipelines.iter().enumerate().skip(1) {
         assert_eq!(
-            p.context_position(),
+            p.context_position().await,
             0,
             "pipeline {} reused context",
             idx + 1

--- a/tests/misc_pipeline_tests/tool_calling.rs
+++ b/tests/misc_pipeline_tests/tool_calling.rs
@@ -8,14 +8,17 @@ fn get_weather(city: String) -> Result<String, ToolError> {
     Ok(format!("The weather in {city} is sunny."))
 }
 
-#[test]
-fn basic_tool_use() -> anyhow::Result<()> {
+#[tokio::test]
+async fn basic_tool_use() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(42)
         .max_len(150)
-        .build()?;
-    pipeline.register_tools(tools![get_weather])?;
-    let out = pipeline.completion_with_tools("What's the weather like in Paris today?")?;
+        .build()
+        .await?;
+    pipeline.register_tools(tools![get_weather]).await?;
+    let out = pipeline
+        .completion_with_tools("What's the weather like in Paris today?")
+        .await?;
     println!("{}", out);
     assert!(out.contains(
         "<tool_result name=\"get_weather\">\nThe weather in Paris is sunny.\n</tool_result>"

--- a/tests/misc_pipeline_tests/tool_error_handling.rs
+++ b/tests/misc_pipeline_tests/tool_error_handling.rs
@@ -8,17 +8,18 @@ fn fail_tool() -> Result<String, ToolError> {
     Err(ToolError::Message("boom".into()))
 }
 
-#[test]
-fn test_tool_fail_strategy() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_tool_fail_strategy() -> anyhow::Result<()> {
     // Fail strategy should propagate the error
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(0)
         .max_len(200)
-        .build()?;
+        .build()
+        .await?;
 
-    pipeline.register_tools(tools![fail_tool])?;
+    pipeline.register_tools(tools![fail_tool]).await?;
 
-    let res = pipeline.completion_with_tools("call fail_tool");
+    let res = pipeline.completion_with_tools("call fail_tool").await;
 
     println!("res: {:?}", res);
 
@@ -32,16 +33,17 @@ fn fail_tool_model() -> Result<String, ToolError> {
     Err(ToolError::Message("boom".into()))
 }
 
-#[test]
-fn test_tool_return_to_model_strategy() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_tool_return_to_model_strategy() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(0)
         .max_len(200)
-        .build()?;
+        .build()
+        .await?;
 
-    pipeline.register_tools(tools![fail_tool_model])?;
+    pipeline.register_tools(tools![fail_tool_model]).await?;
 
-    let res = pipeline.completion_with_tools("call fail_tool_model");
+    let res = pipeline.completion_with_tools("call fail_tool_model").await;
 
     println!("res: {:?}", res);
 

--- a/tests/misc_pipeline_tests/tool_management.rs
+++ b/tests/misc_pipeline_tests/tool_management.rs
@@ -5,23 +5,24 @@ fn echo(msg: String) -> String {
     msg
 }
 
-#[test]
-fn unregister_and_clear() -> anyhow::Result<()> {
+#[tokio::test]
+async fn unregister_and_clear() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(0)
         .max_len(20)
-        .build()?;
+        .build()
+        .await?;
 
-    pipeline.register_tools(tools![echo])?;
-    assert_eq!(pipeline.registered_tools().len(), 1);
+    pipeline.register_tools(tools![echo]).await?;
+    assert_eq!(pipeline.registered_tools().await.len(), 1);
 
-    pipeline.unregister_tool("echo")?;
-    assert!(pipeline.registered_tools().is_empty());
+    pipeline.unregister_tool("echo").await?;
+    assert!(pipeline.registered_tools().await.is_empty());
 
-    pipeline.register_tools(tools![echo])?;
-    assert_eq!(pipeline.registered_tools().len(), 1);
+    pipeline.register_tools(tools![echo]).await?;
+    assert_eq!(pipeline.registered_tools().await.len(), 1);
 
-    pipeline.clear_tools()?;
-    assert!(pipeline.registered_tools().is_empty());
+    pipeline.clear_tools().await?;
+    assert!(pipeline.registered_tools().await.is_empty());
     Ok(())
 }

--- a/tests/sentiment_analysis_pipeline_tests/basic_sentiment_analysis.rs
+++ b/tests/sentiment_analysis_pipeline_tests/basic_sentiment_analysis.rs
@@ -4,28 +4,32 @@
 use transformers::pipelines::sentiment_analysis_pipeline::*;
 use candle_core::DeviceLocation;
 
-#[test]
-fn basic_sentiment() -> anyhow::Result<()> {
-    let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+#[tokio::test]
+async fn basic_sentiment() -> anyhow::Result<()> {
+    let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base)
+        .build()
+        .await?;
     let res = pipeline.predict("I love Rust!")?;
     assert!(!res.trim().is_empty());
     Ok(())
 }
 
-#[test]
-fn select_cpu_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cpu_device() -> anyhow::Result<()> {
     let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base)
         .cpu()
-        .build()?;
+        .build()
+        .await?;
     assert!(pipeline.device().is_cpu());
     Ok(())
 }
 
-#[test]
-fn select_cuda_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cuda_device() -> anyhow::Result<()> {
     let pipeline = SentimentAnalysisPipelineBuilder::modernbert(ModernBertSize::Base)
         .cuda_device(0)
-        .build()?;
+        .build()
+        .await?;
     match pipeline.device().location() {
         DeviceLocation::Cuda { gpu_id } => assert_eq!(gpu_id, 0),
         _ => {}

--- a/tests/text_generation_pipeline_tests/basic_text_generation.rs
+++ b/tests/text_generation_pipeline_tests/basic_text_generation.rs
@@ -4,14 +4,15 @@
 use futures::StreamExt;
 use transformers::pipelines::text_generation_pipeline::*;
 
-#[test]
-fn basic_text_generation() -> anyhow::Result<()> {
+#[tokio::test]
+async fn basic_text_generation() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(42)
         .temperature(0.7)
         .max_len(8)
-        .build()?;
-    let out = pipeline.completion("Rust is a")?;
+        .build()
+        .await?;
+    let out = pipeline.completion("Rust is a").await?;
     assert!(!out.trim().is_empty());
     Ok(())
 }
@@ -21,8 +22,9 @@ async fn basic_streaming() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(42)
         .max_len(8)
-        .build()?;
-    let mut stream = pipeline.completion_stream("Hello")?;
+        .build()
+        .await?;
+    let mut stream = pipeline.completion_stream("Hello").await?;
     let mut acc = String::new();
     while let Some(tok) = stream.next().await {
         acc.push_str(&tok?);
@@ -31,30 +33,32 @@ async fn basic_streaming() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_empty_input_handling() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_empty_input_handling() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(0)
         .max_len(4)
-        .build()?;
-    let out = pipeline.completion("")?;
+        .build()
+        .await?;
+    let out = pipeline.completion("").await?;
     assert!(!out.trim().is_empty());
     Ok(())
 }
 
-#[test]
-fn test_set_generation_params() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_set_generation_params() -> anyhow::Result<()> {
     let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
         .seed(42)
         .max_len(1)
-        .build()?;
+        .build()
+        .await?;
 
-    let short = pipeline.completion("Rust is a")?;
+    let short = pipeline.completion("Rust is a").await?;
 
     let new_params = GenerationParams::new(0.7, 1.0, 64, 42, 8, 1.0, 0, 0.0);
-    pipeline.set_generation_params(new_params);
+    pipeline.set_generation_params(new_params).await;
 
-    let longer = pipeline.completion("Rust is a")?;
+    let longer = pipeline.completion("Rust is a").await?;
 
     assert!(longer.len() >= short.len());
     Ok(())

--- a/tests/zero_shot_pipeline_tests/basic_zero_shot_classification.rs
+++ b/tests/zero_shot_pipeline_tests/basic_zero_shot_classification.rs
@@ -4,21 +4,24 @@
 use transformers::pipelines::zero_shot_classification_pipeline::*;
 use candle_core::DeviceLocation;
 
-#[test]
-fn basic_zero_shot_classification() -> anyhow::Result<()> {
+#[tokio::test]
+async fn basic_zero_shot_classification() -> anyhow::Result<()> {
     let pipeline =
-        ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base).build()?;
+        ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base)
+            .build()
+            .await?;
     let labels = ["politics", "sports"];
     let res = pipeline.predict("The election results were surprising", &labels)?;
     assert_eq!(res.len(), 2);
     Ok(())
 }
 
-#[test]
-fn select_cuda_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cuda_device() -> anyhow::Result<()> {
     let pipeline = ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base)
         .cuda_device(0)
-        .build()?;
+        .build()
+        .await?;
     match pipeline.device().location() {
         DeviceLocation::Cuda { gpu_id } => assert_eq!(gpu_id, 0),
         _ => {}
@@ -26,11 +29,12 @@ fn select_cuda_device() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn select_cpu_device() -> anyhow::Result<()> {
+#[tokio::test]
+async fn select_cpu_device() -> anyhow::Result<()> {
     let pipeline = ZeroShotClassificationPipelineBuilder::modernbert(ModernBertSize::Base)
         .cpu()
-        .build()?;
+        .build()
+        .await?;
     assert!(pipeline.device().is_cpu());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add tokio dependency and switch internal mutexes to tokio
- make BasePipeline and text generation pipelines async
- update model cache and builders for async usage
- update examples and tests to use async API

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_6868c132f30483309f7cdbefc699182a