### PR TITLE
Improve streaming internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "minijinja",
  "minijinja-contrib",
  "once_cell",
+ "pin-project-lite",
  "rand 0.9.1",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.
 hf-hub = "0.4.3"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
+pin-project-lite = "0.2"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ fn main() -> anyhow::Result<()> {
 
 #### XML Parsing for Structured Output
 
-You can build pipelines with XML parsing capabilities to handle structured outputs from models. This is particularly useful for parsing tool calls, reasoning traces, or any XML-tagged content in model responses.
+You can build pipelines with XML parsing capabilities to handle structured outputs from models. This is particularly useful for parsing tool calls, and reasoning traces.
 
 ```rust
 use transformers::pipelines::text_generation_pipeline::*;

--- a/README.md
+++ b/README.md
@@ -245,6 +245,47 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
+#### XML Parsing for Structured Output
+
+You can build pipelines with XML parsing capabilities to handle structured outputs from models. This is particularly useful for parsing tool calls, reasoning traces, or any XML-tagged content in model responses.
+
+```rust
+use transformers::pipelines::text_generation_pipeline::*;
+
+fn main() -> anyhow::Result<()> {
+    // 1. Build a pipeline with XML parsing for specific tags
+    let pipeline = TextGenerationPipelineBuilder::qwen3(Qwen3Size::Size0_6B)
+        .max_len(1024)
+        .build_xml(&["think", "tool_result", "tool_call"])
+        .await?;
+
+    // 2. Generate completion - returns Vec<Event> instead of String
+    let events = pipeline.completion("Explain your reasoning step by step.").await?;
+
+    // 3. Process events based on tags
+    for event in events {
+        match event.tag() {
+            Some("think") => match event.part() {
+                TagParts::Start => println!("[THINKING]"),
+                TagParts::Content => print!("{}", event.get_content()),
+                TagParts::End => println!("[END THINKING]"),
+            },
+            None => {
+                // Regular content outside tags
+                if event.part() == TagParts::Content {
+                    print!("{}", event.get_content());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+```
+
+The XML parser also works with streaming completions, emitting events as XML tags are encountered in the stream. This enables real-time processing of structured outputs without waiting for the full response.
+
 ### Fill Mask (ModernBERT)
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     // 3. Do something with tokens as they are generated
-    futures::pin_mut!(stream);
     while let Some(tok) = stream.next().await {
         print!("{}", tok);
         std::io::stdout().flush().unwrap();

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The `Message` struct represents a single message in a chat and has a `role` (sys
 ```rust
 use transformers::pipelines::text_generation_pipeline::TextGenerationPipelineBuilder;
 use transformers::pipelines::text_generation_pipeline::Messages;
+use futures::StreamExt;
 
 fn main() -> anyhow::Result<()> {
     // 1. Create the pipeline
@@ -235,6 +236,7 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     // 3. Do something with tokens as they are generated
+    futures::pin_mut!(stream);
     while let Some(tok) = stream.next().await {
         print!("{}", tok);
         std::io::stdout().flush().unwrap();

--- a/examples/text_generation_streaming.rs
+++ b/examples/text_generation_streaming.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
+use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -14,6 +15,7 @@ async fn main() -> Result<()> {
         "Explain the concept of Large Language Models in simple terms.",
     )
     .await?;
+    futures::pin_mut!(stream);
 
     println!("\n--- Generated Text ---");
     while let Some(tok) = stream.next().await {
@@ -28,6 +30,7 @@ async fn main() -> Result<()> {
     ];
 
     let mut stream_two = pipeline.completion_stream(&messages).await?;
+    futures::pin_mut!(stream_two);
 
     println!("\n--- Generated Text 2 ---");
     while let Some(tok) = stream_two.next().await {

--- a/examples/text_generation_streaming.rs
+++ b/examples/text_generation_streaming.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
+use std::io::Write;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/examples/text_generation_streaming.rs
+++ b/examples/text_generation_streaming.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
-use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/examples/text_generation_streaming.rs
+++ b/examples/text_generation_streaming.rs
@@ -15,7 +15,6 @@ async fn main() -> Result<()> {
         "Explain the concept of Large Language Models in simple terms.",
     )
     .await?;
-    futures::pin_mut!(stream);
 
     println!("\n--- Generated Text ---");
     while let Some(tok) = stream.next().await {
@@ -30,7 +29,6 @@ async fn main() -> Result<()> {
     ];
 
     let mut stream_two = pipeline.completion_stream(&messages).await?;
-    futures::pin_mut!(stream_two);
 
     println!("\n--- Generated Text 2 ---");
     while let Some(tok) = stream_two.next().await {

--- a/examples/text_generation_tools.rs
+++ b/examples/text_generation_tools.rs
@@ -39,7 +39,6 @@ async fn main() -> Result<()> {
         pipeline
             .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
             .await?;
-    futures::pin_mut!(stream);
 
     println!("Generating text 1...");
 
@@ -54,7 +53,6 @@ async fn main() -> Result<()> {
         pipeline
             .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
             .await?;
-    futures::pin_mut!(stream);
 
     println!("Generating text 2...");
 

--- a/examples/text_generation_tools.rs
+++ b/examples/text_generation_tools.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::ToolError;
 use transformers::pipelines::text_generation_pipeline::*;
+use std::io::Write;
 
 #[tool(on_error = ErrorStrategy::Fail, retries = 5)]
 /// Get the weather for a given city.

--- a/examples/text_generation_tools.rs
+++ b/examples/text_generation_tools.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::ToolError;
 use transformers::pipelines::text_generation_pipeline::*;
+use futures::StreamExt;
 
 #[tool(on_error = ErrorStrategy::Fail, retries = 5)]
 /// Get the weather for a given city.
@@ -38,6 +39,7 @@ async fn main() -> Result<()> {
         pipeline
             .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
             .await?;
+    futures::pin_mut!(stream);
 
     println!("Generating text 1...");
 
@@ -52,6 +54,7 @@ async fn main() -> Result<()> {
         pipeline
             .completion_stream_with_tools("What's the temp and humidity like in Tokyo?")
             .await?;
+    futures::pin_mut!(stream);
 
     println!("Generating text 2...");
 

--- a/examples/text_generation_tools.rs
+++ b/examples/text_generation_tools.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::ToolError;
 use transformers::pipelines::text_generation_pipeline::*;
-use futures::StreamExt;
 
 #[tool(on_error = ErrorStrategy::Fail, retries = 5)]
 /// Get the weather for a given city.

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
+use futures::StreamExt;
 
 #[tool]
 /// Calculates the average speed given distance and time
@@ -33,6 +34,7 @@ async fn main() -> Result<()> {
     let mut stream = pipeline
         .completion_stream_with_tools("What's the weather like in Tokyo?")
         .await?;
+    futures::pin_mut!(stream);
 
     println!("\n--- Streaming Events ---");
 

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use futures::{pin_mut, StreamExt};
 use transformers::pipelines::text_generation_pipeline::*;
 
 #[tool]
@@ -31,10 +30,9 @@ async fn main() -> Result<()> {
     pipeline.register_tools(tools![get_weather]).await?;
 
     // Stream completion - this will yield Event items
-    let stream = pipeline
+    let mut stream = pipeline
         .completion_stream_with_tools("What's the weather like in Tokyo?")
         .await?;
-    pin_mut!(stream);
 
     println!("\n--- Streaming Events ---");
 

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -34,7 +34,6 @@ async fn main() -> Result<()> {
     let mut stream = pipeline
         .completion_stream_with_tools("What's the weather like in Tokyo?")
         .await?;
-    futures::pin_mut!(stream);
 
     println!("\n--- Streaming Events ---");
 

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use transformers::pipelines::text_generation_pipeline::*;
+use std::io::Write;
 
 #[tool]
 /// Calculates the average speed given distance and time

--- a/examples/xml_parser_streaming.rs
+++ b/examples/xml_parser_streaming.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
+use futures::{pin_mut, StreamExt};
 use transformers::pipelines::text_generation_pipeline::*;
-use futures::StreamExt;
 
 #[tool]
 /// Calculates the average speed given distance and time
@@ -31,9 +31,10 @@ async fn main() -> Result<()> {
     pipeline.register_tools(tools![get_weather]).await?;
 
     // Stream completion - this will yield Event items
-    let mut stream = pipeline
+    let stream = pipeline
         .completion_stream_with_tools("What's the weather like in Tokyo?")
         .await?;
+    pin_mut!(stream);
 
     println!("\n--- Streaming Events ---");
 

--- a/src/pipelines/text_generation_pipeline/event_stream.rs
+++ b/src/pipelines/text_generation_pipeline/event_stream.rs
@@ -1,0 +1,127 @@
+use futures::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use pin_project_lite::pin_project;
+use super::xml_parser::Event;
+
+/// Convenience wrapper around the streaming output of XML pipeline.
+pin_project! {
+    pub struct EventStream<S> {
+        #[pin]
+        inner: Pin<Box<S>>,
+    }
+}
+
+impl<S> Unpin for EventStream<S> {}
+
+impl<S> EventStream<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        Self { inner: Box::pin(inner) }
+    }
+
+    /// Get the next event from the stream.
+    /// 
+    /// Returns `None` when the stream is exhausted.
+    pub async fn next(&mut self) -> Option<Event>
+    where
+        S: Stream<Item = Event>,
+    {
+        use futures::StreamExt;
+        self.inner.as_mut().next().await
+    }
+
+    /// Collect all events into a vector.
+    pub async fn collect(mut self) -> Vec<Event>
+    where
+        S: Stream<Item = Event>,
+    {
+        use futures::StreamExt;
+        let mut events = Vec::new();
+        while let Some(event) = self.inner.as_mut().next().await {
+            events.push(event);
+        }
+        events
+    }
+
+    /// Collect only the content from events, ignoring start/end markers.
+    pub async fn collect_content(mut self) -> String
+    where
+        S: Stream<Item = Event>,
+    {
+        use futures::StreamExt;
+        use super::xml_parser::TagParts;
+        let mut out = String::new();
+        while let Some(event) = self.inner.as_mut().next().await {
+            if event.part() == TagParts::Content {
+                out.push_str(event.get_content());
+            }
+        }
+        out
+    }
+
+    /// Take up to `n` events from the stream.
+    pub async fn take(mut self, n: usize) -> Vec<Event>
+    where
+        S: Stream<Item = Event>,
+    {
+        use futures::StreamExt;
+        let mut events = Vec::new();
+        for _ in 0..n {
+            match self.inner.as_mut().next().await {
+                Some(event) => events.push(event),
+                None => break,
+            }
+        }
+        events
+    }
+
+    /// Filter events based on a predicate.
+    pub fn filter<F>(self, f: F) -> EventStream<impl Stream<Item = Event>>
+    where
+        S: Stream<Item = Event>,
+        F: FnMut(&Event) -> bool,
+    {
+        use futures::StreamExt;
+        EventStream::new(self.inner.filter(f))
+    }
+
+    /// Map each event through a function.
+    pub fn map<F, T>(self, f: F) -> EventStream<impl Stream<Item = T>>
+    where
+        S: Stream<Item = Event>,
+        F: FnMut(Event) -> T,
+    {
+        use futures::StreamExt;
+        EventStream::new(self.inner.map(f))
+    }
+
+    /// Filter events by tag name.
+    pub fn filter_tag(self, tag_name: &str) -> EventStream<impl Stream<Item = Event>>
+    where
+        S: Stream<Item = Event>,
+    {
+        let tag_name = tag_name.to_string();
+        self.filter(move |event| event.tag() == Some(&tag_name))
+    }
+
+    /// Get only content events (excluding start/end markers).
+    pub fn content_only(self) -> EventStream<impl Stream<Item = Event>>
+    where
+        S: Stream<Item = Event>,
+    {
+        use super::xml_parser::TagParts;
+        self.filter(|event| event.part() == TagParts::Content)
+    }
+}
+
+impl<S> Stream for EventStream<S>
+where
+    S: Stream<Item = Event>, 
+{
+    type Item = Event;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        this.inner.as_mut().as_mut().poll_next(cx)
+    }
+}

--- a/src/pipelines/text_generation_pipeline/event_stream.rs
+++ b/src/pipelines/text_generation_pipeline/event_stream.rs
@@ -4,15 +4,13 @@ use std::task::{Context, Poll};
 use pin_project_lite::pin_project;
 use super::xml_parser::Event;
 
-/// Convenience wrapper around the streaming output of XML pipeline.
 pin_project! {
+    /// Convenience wrapper around the streaming output of XML pipeline.
     pub struct EventStream<S> {
         #[pin]
         inner: Pin<Box<S>>,
     }
 }
-
-impl<S> Unpin for EventStream<S> {}
 
 impl<S> EventStream<S> {
     pub(crate) fn new(inner: S) -> Self {
@@ -76,13 +74,13 @@ impl<S> EventStream<S> {
     }
 
     /// Filter events based on a predicate.
-    pub fn filter<F>(self, f: F) -> EventStream<impl Stream<Item = Event>>
+    pub fn filter<F>(self, mut f: F) -> EventStream<impl Stream<Item = Event>>
     where
         S: Stream<Item = Event>,
         F: FnMut(&Event) -> bool,
     {
         use futures::StreamExt;
-        EventStream::new(self.inner.filter(f))
+        EventStream::new(self.inner.filter(move |item| std::future::ready(f(item))))
     }
 
     /// Map each event through a function.

--- a/src/pipelines/text_generation_pipeline/mod.rs
+++ b/src/pipelines/text_generation_pipeline/mod.rs
@@ -1,5 +1,6 @@
 pub mod base_pipeline;
 pub mod completion_stream;
+pub mod event_stream;
 pub mod text_generation_model;
 pub mod text_generation_pipeline;
 pub mod text_generation_pipeline_builder;
@@ -9,6 +10,7 @@ pub mod xml_parser;
 
 pub use crate::tools;
 pub use completion_stream::CompletionStream;
+pub use event_stream::EventStream;
 pub use text_generation_pipeline::{Input, TextGenerationPipeline};
 pub use text_generation_pipeline_builder::TextGenerationPipelineBuilder;
 pub use xml_generation_pipeline::XmlGenerationPipeline;

--- a/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_generation_pipeline.rs
@@ -5,16 +5,11 @@ use super::text_generation_model::{
 };
 use super::text_generation_pipeline::Input;
 use super::xml_parser::{Event, XmlParser};
-use crate::models::generation::{
-    apply_repeat_penalty, initialize_logits_processor, GenerationParams,
-};
-use async_stream::try_stream;
-use candle_core::Tensor;
-use futures::Stream;
+use crate::models::generation::GenerationParams;
+use async_stream::stream;
 use regex::Regex;
 use serde::Deserialize;
-use std::pin::Pin;
-use std::sync::Arc;
+use futures::Stream;
 
 /// XML generation pipeline that outputs parsed Events
 pub struct XmlGenerationPipeline<M: TextGenerationModel> {
@@ -133,232 +128,89 @@ impl<M: TextGenerationModel + Send> XmlGenerationPipeline<M> {
     pub async fn completion_stream<'a>(
         &'a self,
         input: impl Into<Input<'a>>,
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + 'a>>> {
+    ) -> anyhow::Result<impl Stream<Item = Event> + Send + 'a> {
         match input.into() {
-            Input::Prompt(p) => self.prompt_completion_stream(p).await,
-            Input::Messages(m) => self.message_completion_stream(m).await,
+            Input::Prompt(p) => {
+                self.base.context.lock().await.reset();
+                let templated = self
+                    .base
+                    .model
+                    .lock()
+                    .await
+                    .apply_chat_template(&[crate::Message::user(p)])?;
+                let tokens = self
+                    .base
+                    .model_tokenizer
+                    .encode(templated, true)
+                    .map_err(|e| anyhow::anyhow!(e))?
+                    .get_ids()
+                    .to_vec();
+
+                Ok(self.event_stream_from_tokens(tokens))
+            }
+            Input::Messages(m) => {
+                let templated = self
+                    .base
+                    .model
+                    .lock()
+                    .await
+                    .apply_chat_template(m)?;
+                let new_tokens = self
+                    .base
+                    .model_tokenizer
+                    .encode(templated, true)
+                    .map_err(|e| anyhow::anyhow!(e))?
+                    .get_ids()
+                    .to_vec();
+
+                let max_seq = self.base.model.lock().await.get_max_seq_len();
+                if self.base.context.lock().await.position() + new_tokens.len() > max_seq {
+                    self.base.context.lock().await.reset();
+                    self.base.last_processed_tokens.lock().await.clear();
+                } else if self.base.can_reuse_cache(&new_tokens).await {
+                    let suffix = new_tokens[self.base.last_processed_tokens.lock().await.len()..].to_vec();
+                    *self.base.last_processed_tokens.lock().await = new_tokens;
+                    return Ok(self.event_stream_from_tokens(suffix));
+                } else {
+                    self.base.context.lock().await.reset();
+                }
+
+                *self.base.last_processed_tokens.lock().await = new_tokens.clone();
+                Ok(self.event_stream_from_tokens(new_tokens))
+            }
         }
     }
 
-    async fn prompt_completion_stream(
-        &self,
-        prompt: &str,
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + '_>>> {
-        // Fresh turn → reset context
-        self.base.context.lock().await.reset();
-
-        let templated = self
-            .base
-            .model
-            .lock()
-            .await
-            .apply_chat_template(&[crate::Message::user(prompt)])?;
-        let tokens = self
-            .base
-            .model_tokenizer
-            .encode(templated, true)
-            .map_err(|e| anyhow::anyhow!(e))?
-            .get_ids()
-            .to_vec();
-
-        use futures::StreamExt;
-        let inner = self.raw_completion_stream(tokens);
-
-        self.xml_parser.reset();
-        let parser = self.xml_parser.clone();
-
-        use async_stream::stream;
-        Ok(Box::pin(stream! {
-            futures::pin_mut!(inner);
-            while let Some(result) = inner.next().await {
-                let token = result.expect("stream generation failed");
-                let events = parser.parse_token(&token);
-                for event in events {
-                    yield event;
-                }
-            }
-
-            // Flush any remaining events
-            let final_events = parser.flush();
-            for event in final_events {
-                yield event;
-            }
-        }))
-    }
-
-    async fn message_completion_stream(
-        &self,
-        messages: &[crate::Message],
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + '_>>> {
-        let templated = self
-            .base
-            .model
-            .lock()
-            .await
-            .apply_chat_template(messages)?;
-        let new_tokens = self
-            .base
-            .model_tokenizer
-            .encode(templated, true)
-            .map_err(|e| anyhow::anyhow!(e))?
-            .get_ids()
-            .to_vec();
-
-        // Same cache logic
-        let max_seq = self.base.model.lock().await.get_max_seq_len();
-        if self.base.context.lock().await.position() + new_tokens.len() > max_seq {
-            self.base.context.lock().await.reset();
-            self.base.last_processed_tokens.lock().await.clear();
-        } else if self.base.can_reuse_cache(&new_tokens).await {
-            let suffix =
-                new_tokens[self.base.last_processed_tokens.lock().await.len()..].to_vec();
-            *self.base.last_processed_tokens.lock().await = new_tokens;
-
-            let inner = self.raw_completion_stream(suffix);
-            self.xml_parser.reset();
-            let parser = self.xml_parser.clone();
-
-            use async_stream::stream;
-            use futures::StreamExt;
-            return Ok(Box::pin(stream! {
-                futures::pin_mut!(inner);
-                while let Some(result) = inner.next().await {
-                    let token = result.expect("stream generation failed");
-                    let events = parser.parse_token(&token);
-                    for event in events {
-                        yield event;
-                    }
-                }
-
-                // Flush any remaining events
-                let final_events = parser.flush();
-                for event in final_events {
-                    yield event;
-                }
-            }));
-        } else {
-            self.base.context.lock().await.reset();
-        }
-
-        *self.base.last_processed_tokens.lock().await = new_tokens.clone();
-        let inner = self.raw_completion_stream(new_tokens);
-
-        self.xml_parser.reset();
-        let parser = self.xml_parser.clone();
-
-        use async_stream::stream;
-        use futures::StreamExt;
-        Ok(Box::pin(stream! {
-            futures::pin_mut!(inner);
-            while let Some(result) = inner.next().await {
-                let token = result.expect("stream generation failed");
-                let events = parser.parse_token(&token);
-                for event in events {
-                    yield event;
-                }
-            }
-
-            // Flush any remaining events
-            let final_events = parser.flush();
-            for event in final_events {
-                yield event;
-            }
-        }))
-    }
-
-    fn raw_completion_stream<'a>(
+    fn event_stream_from_tokens<'a>(
         &'a self,
-        input_tokens: Vec<u32>,
-    ) -> Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send + 'a>>
+        tokens: Vec<u32>,
+    ) -> impl Stream<Item = Event> + Send + 'a
     where
-        M: 'a,
+        M: Send + 'a,
     {
-        // Capture everything the async generator needs **by value**
-        let device = self.base.device.clone();
-        let model = Arc::clone(&self.base.model);
-        let tokenizer = self.base.model_tokenizer.clone();
-        let context = Arc::clone(&self.base.context);
-        let gen_params = Arc::clone(&self.base.gen_params);
+        use futures::StreamExt;
+        use async_stream::stream;
 
-        Box::pin(try_stream! {
-            let params = gen_params.lock().await.clone();
-            let eos_tokens = model.lock().await.get_eos_tokens();
-            const CHUNK_SIZE: usize = 64;
+        let inner = self.base.token_stream(tokens);
 
-            let mut logits_processor =
-                initialize_logits_processor(&params, params.seed);
+        self.xml_parser.reset();
+        let parser = self.xml_parser.clone();
 
-            // Send the whole prompt first
-            let mut idx = 0;
-            let mut last_logits = None;
-            while idx < input_tokens.len() {
-                let end   = usize::min(idx + CHUNK_SIZE, input_tokens.len());
-                let chunk = &input_tokens[idx..end];
-
-                let input  = Tensor::new(chunk, &device)?.unsqueeze(0)?;
-                let logits = {
-                    let mut ctx = context.lock().await;
-                    ctx.generate(&input)
-                }?;
-                last_logits = Some(logits.squeeze(0)?);
-                idx = end;
-            }
-
-            // First sampled token
-            let mut generated: Vec<u32> = Vec::with_capacity(params.max_len);
-
-            // Incremental decoder that keeps special tokens
-            let mut dec_full  = tokenizer.decode_stream(false);
-
-            let mut next_token = logits_processor.sample(&last_logits.unwrap())?;
-            generated.push(next_token);
-
-            // Skip yielding if this token is an EOS token
-            if !eos_tokens.contains(&next_token) {
-                if let Some(chunk) = dec_full.step(next_token).map_err(|e| anyhow::anyhow!(e))? {
-                    yield chunk;
-                }
-            } else {
-                // Still need to step the decoder to keep state consistent, but don't yield
-                let _ = dec_full.step(next_token).map_err(|e| anyhow::anyhow!(e))?;
-            }
-
-            // Autoregressive loop
-            for _ in 0..params.max_len {
-                if eos_tokens.contains(&next_token) {
-                    break;
-                }
-
-                let input  = Tensor::new(&[next_token], &device)?.unsqueeze(0)?;
-                let logits = {
-                    let mut ctx = context.lock().await;
-                    ctx.generate(&input)
-                }?;
-                let logits = logits.squeeze(0)?;
-
-                let start_at = generated.len().saturating_sub(params.repeat_last_n);
-                let penalty_context = &generated[start_at..];
-
-                let logits = if params.repeat_penalty <= 1. || penalty_context.is_empty() {
-                    logits
-                } else {
-                    apply_repeat_penalty(&logits, params.repeat_penalty, penalty_context)?
-                };
-
-                next_token = logits_processor.sample(&logits)?;
-                generated.push(next_token);
-
-                // Skip yielding if this token is an EOS token
-                if !eos_tokens.contains(&next_token) {
-                    if let Some(chunk) = dec_full.step(next_token).map_err(|e| anyhow::anyhow!(e))? {
-                        yield chunk;
-                    }
-                } else {
-                    // Still need to step the decoder, but don't yield
-                    let _ = dec_full.step(next_token).map_err(|e| anyhow::anyhow!(e))?;
+        stream! {
+            futures::pin_mut!(inner);
+            while let Some(result) = inner.next().await {
+                let token = result.expect("stream generation failed");
+                let events = parser.parse_token(&token);
+                for event in events {
+                    yield event;
                 }
             }
-        })
+
+            let final_events = parser.flush();
+            for event in final_events {
+                yield event;
+            }
+        }
     }
 }
 
@@ -403,7 +255,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
 
     /// Execute a list of tool calls with retry logic and error handling
     /// Returns a vector of formatted tool responses
-    fn execute_tool_calls(
+    async fn execute_tool_calls(
         &self,
         tool_calls: Vec<ToolCallInvocation>,
         tools: &[Tool],
@@ -449,7 +301,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                                 }
                             }
                         } else {
-                            std::thread::sleep(std::time::Duration::from_millis(50));
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                         }
                     }
                 }
@@ -521,7 +373,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                     messages.push(crate::Message::assistant(&response));
 
                     // Execute tools and get responses
-                    let tool_responses = self.execute_tool_calls(tool_calls, &tools)?;
+                    let tool_responses = self.execute_tool_calls(tool_calls, &tools).await?;
                     let tool_response_text = tool_responses.join("\n");
 
                     // Append tool results and ensure a single trailing newline for spacing
@@ -550,7 +402,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
     pub async fn completion_stream_with_tools<'a>(
         &'a self,
         input: impl Into<Input<'a>>,
-    ) -> anyhow::Result<Pin<Box<dyn Stream<Item = Event> + Send + 'a>>> {
+    ) -> anyhow::Result<impl Stream<Item = Event> + Send + 'a> {
         use async_stream::stream;
         use futures::StreamExt;
 
@@ -566,7 +418,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
 
         let xml_parser = self.xml_parser.clone();
 
-        Ok(Box::pin(stream! {
+        Ok(stream! {
             let mut messages = initial_messages;
             let mut raw_buffer = String::new();  // Keep raw text with tags
 
@@ -609,7 +461,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                         new_tokens
                     };
 
-                    let stream_inner = self.raw_completion_stream(tokens_to_process);
+                    let stream_inner = self.base.token_stream(tokens_to_process);
                     futures::pin_mut!(stream_inner);
 
                     while let Some(result) = stream_inner.next().await {
@@ -645,7 +497,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                         raw_buffer.clear();
 
                         // Execute tools
-                        let tool_responses = match self.execute_tool_calls(tool_calls, &tools) {
+                        let tool_responses = match self.execute_tool_calls(tool_calls, &tools).await {
                             Ok(responses) => responses,
                             Err(_e) => {
                                 // Error executing tools, break out
@@ -673,7 +525,7 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
                     }
                 }
             }
-        }))
+        })
     }
 
     fn extract_tool_calls(text: &str) -> anyhow::Result<Vec<ToolCallInvocation>> {


### PR DESCRIPTION
## Summary
- make async tool execution non-blocking
- deduplicate streaming generation logic
- switch completion streams to use concrete stream types

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_686989baf4808330b67d90f0f9cc07d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new asynchronous token streaming method for incremental text generation.
  * Added a generic streaming wrapper with combinator methods for flexible processing of generated text.
  * Added a typed event stream wrapper for XML generation with filtering and mapping utilities.
  * Enabled asynchronous execution of tool calls with non-blocking delays.

* **Refactor**
  * Unified and simplified streaming logic for text and XML generation pipelines.
  * Delegated token generation to a centralized streaming method for consistency.
  * Improved stream safety and pinning using a new dependency.
  * Updated streaming methods to use generic streams and enhanced combinators.

* **Documentation**
  * Extended README with examples demonstrating XML parsing and streaming event handling.

* **Chores**
  * Added a new dependency to support safer pin projection in streams.
  * Imported output flushing utilities in examples to ensure immediate streaming output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->