### PR TITLE
Add Qwen3 embeddings and pipeline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,12 @@ pub use core::{Message, MessageVecExt};
 
 // Re-export model types for easier access
 pub use models::implementations::{
-    Gemma3Model, Gemma3Size, ModernBertModel, ModernBertSize, Qwen3Model, Qwen3Size,
+    Gemma3Model,
+    Gemma3Size,
+    ModernBertModel,
+    ModernBertSize,
+    Qwen3Model,
+    Qwen3Size,
+    Qwen3EmbeddingModel,
+    Qwen3EmbeddingSize,
 };

--- a/src/models/implementations/mod.rs
+++ b/src/models/implementations/mod.rs
@@ -1,7 +1,9 @@
 pub mod gemma3;
 pub mod modernbert;
 pub mod qwen3;
+pub mod qwen3_embeddings;
 
 pub use gemma3::{Gemma3Model, Gemma3Size};
 pub use modernbert::{ModernBertModel, ModernBertSize};
 pub use qwen3::{Qwen3Model, Qwen3Size};
+pub use qwen3_embeddings::{Qwen3EmbeddingModel, Qwen3EmbeddingSize};

--- a/src/models/implementations/qwen3_embeddings.rs
+++ b/src/models/implementations/qwen3_embeddings.rs
@@ -1,0 +1,155 @@
+use std::sync::Arc;
+
+use candle_core::{Device, Tensor, Result, DType};
+use tokenizers::Tokenizer;
+
+use super::qwen3::{ModelWeights};
+use crate::loaders::{GgufModelLoader, TokenizerLoader};
+use crate::core::ModelOptions;
+
+/// Available Qwen3 embedding model sizes.
+#[derive(Debug, Clone, Copy)]
+pub enum Qwen3EmbeddingSize {
+    Size0_6B,
+    Size4B,
+    Size8B,
+}
+
+impl Qwen3EmbeddingSize {
+    pub fn to_id(&self) -> (String, String) {
+        match self {
+            Qwen3EmbeddingSize::Size0_6B => (
+                "Qwen/Qwen3-Embedding-0.6B-GGUF".into(),
+                "qwen3-embedding-0.6b-q4_k_m.gguf".into(),
+            ),
+            Qwen3EmbeddingSize::Size4B => (
+                "Qwen/Qwen3-Embedding-4B-GGUF".into(),
+                "qwen3-embedding-4b-q4_k_m.gguf".into(),
+            ),
+            Qwen3EmbeddingSize::Size8B => (
+                "Qwen/Qwen3-Embedding-8B-GGUF".into(),
+                "qwen3-embedding-8b-q4_k_m.gguf".into(),
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for Qwen3EmbeddingSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Qwen3EmbeddingSize::Size0_6B => "qwen3-embedding-0.6b",
+            Qwen3EmbeddingSize::Size4B => "qwen3-embedding-4b",
+            Qwen3EmbeddingSize::Size8B => "qwen3-embedding-8b",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl ModelOptions for Qwen3EmbeddingSize {
+    fn cache_key(&self) -> String {
+        self.to_string()
+    }
+}
+
+/// Qwen3 model for generating text embeddings.
+#[derive(Clone)]
+pub struct Qwen3EmbeddingModel {
+    weights: Arc<ModelWeights>,
+    device: Device,
+}
+
+impl Qwen3EmbeddingModel {
+    pub async fn from_hf(device: &Device, size: Qwen3EmbeddingSize) -> anyhow::Result<Self> {
+        let (repo_id, file_name) = size.to_id();
+        let loader = GgufModelLoader::new(&repo_id, &file_name);
+        let (mut file, content) = loader.load().await?;
+        let weights = Arc::new(ModelWeights::from_gguf(content, &mut file, device)?);
+        Ok(Self { weights, device: device.clone() })
+    }
+
+    pub async fn get_tokenizer(&self) -> anyhow::Result<Tokenizer> {
+        let loader = TokenizerLoader::new("Qwen/Qwen3-Embedding-0.6B-GGUF", "tokenizer.json");
+        loader.load().await
+    }
+
+    /// Generate an embedding for the provided text.
+    pub fn embed(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<Vec<f32>> {
+        const EOS: &str = "<|endoftext|>";
+        let encoded = tokenizer
+            .encode(format!("{text}{EOS}"), false)
+            .map_err(anyhow::Error::msg)?;
+        let ids = encoded.get_ids();
+        let input = Tensor::new(ids, &self.device)?.unsqueeze(0)?;
+        let mask = create_causal_mask(&self.device, 1, ids.len(), 0)?;
+        let emb = self
+            .weights
+            .forward_embedding(&input, Some(&mask))?;
+        let emb = l2_normalise(emb)?;
+        Ok(emb.to_vec1::<f32>()?)
+    }
+
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+}
+
+fn l2_normalise(t: Tensor) -> Result<Tensor> {
+    let norm = t.sqr()?.sum_keepdim(candle_core::D::Minus1)?.sqrt()?;
+    t.broadcast_div(&norm)
+}
+
+fn create_causal_mask(
+    device: &Device,
+    batch_size: usize,
+    seq_len: usize,
+    position_offset: usize,
+) -> Result<Tensor> {
+    let total_len = seq_len + position_offset;
+
+    let row_ids = Tensor::arange(0u32, seq_len as u32, device)?
+        .to_dtype(DType::I64)?
+        .reshape((seq_len, 1))?
+        .broadcast_add(&Tensor::new(&[position_offset as i64], device)?)?;
+
+    let col_ids = Tensor::arange(0u32, total_len as u32, device)?
+        .to_dtype(DType::I64)?
+        .reshape((1, total_len))?;
+
+    let mask = row_ids
+        .broadcast_as(&[seq_len, total_len])?
+        .ge(&col_ids.broadcast_as(&[seq_len, total_len])?)?;
+
+    let neg_inf = Tensor::new(&[f32::NEG_INFINITY], device)?.broadcast_as(&[seq_len, total_len])?;
+    let zero = Tensor::zeros(&[seq_len, total_len], DType::F32, device)?;
+
+    let float_mask = mask.where_cond(&zero, &neg_inf)?;
+
+    float_mask
+        .unsqueeze(0)?
+        .unsqueeze(0)?
+        .broadcast_as(&[batch_size, 1, seq_len, total_len])
+}
+
+use crate::pipelines::embedding_pipeline::embedding_model::EmbeddingModel;
+
+impl EmbeddingModel for Qwen3EmbeddingModel {
+    type Options = Qwen3EmbeddingSize;
+
+    fn new(options: Self::Options, device: Device) -> anyhow::Result<Self> {
+        futures::executor::block_on(Self::from_hf(&device, options))
+    }
+
+    fn embed(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.embed(tokenizer, text)
+    }
+
+    fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer> {
+        let (repo, _) = options.to_id();
+        let loader = TokenizerLoader::new(&repo, "tokenizer.json");
+        futures::executor::block_on(loader.load())
+    }
+
+    fn device(&self) -> &Device {
+        &self.device
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,4 +6,13 @@ pub mod implementations;
 pub use components::{QMatMul, RmsNorm, VarBuilder, repeat_kv};
 
 // Re-export model implementations
-pub use implementations::{Gemma3Model, Gemma3Size, ModernBertModel, ModernBertSize, Qwen3Model, Qwen3Size};
+pub use implementations::{
+    Gemma3Model,
+    Gemma3Size,
+    ModernBertModel,
+    ModernBertSize,
+    Qwen3Model,
+    Qwen3Size,
+    Qwen3EmbeddingModel,
+    Qwen3EmbeddingSize,
+};

--- a/src/pipelines/embedding_pipeline/builder.rs
+++ b/src/pipelines/embedding_pipeline/builder.rs
@@ -1,0 +1,53 @@
+use super::embedding_model::EmbeddingModel;
+use super::embedding_pipeline::EmbeddingPipeline;
+use crate::core::{global_cache, ModelOptions};
+
+pub struct EmbeddingPipelineBuilder<M: EmbeddingModel> {
+    options: M::Options,
+    device: Option<candle_core::Device>,
+}
+
+impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
+    pub fn new(options: M::Options) -> Self {
+        Self { options, device: None }
+    }
+
+    pub fn cpu(mut self) -> Self {
+        self.device = Some(candle_core::Device::Cpu);
+        self
+    }
+
+    pub fn cuda_device(mut self, index: usize) -> Self {
+        let dev = candle_core::Device::new_cuda_with_stream(index).unwrap_or(candle_core::Device::Cpu);
+        self.device = Some(dev);
+        self
+    }
+
+    pub fn device(mut self, device: candle_core::Device) -> Self {
+        self.device = Some(device);
+        self
+    }
+
+    pub async fn build(self) -> anyhow::Result<EmbeddingPipeline<M>>
+    where
+        M: Clone + Send + Sync + 'static,
+        M::Options: ModelOptions + Clone,
+    {
+        let device = match self.device {
+            Some(d) => d,
+            None => crate::pipelines::utils::load_device()?,
+        };
+        let key = format!("{}-{:?}", self.options.cache_key(), device.location());
+        let model = global_cache()
+            .get_or_create(&key, || M::new(self.options.clone(), device.clone()))
+            .await?;
+        let tokenizer = M::get_tokenizer(self.options)?;
+        Ok(EmbeddingPipeline { model, tokenizer })
+    }
+}
+
+impl EmbeddingPipelineBuilder<crate::models::implementations::qwen3_embeddings::Qwen3EmbeddingModel> {
+    pub fn qwen3(size: crate::models::implementations::qwen3_embeddings::Qwen3EmbeddingSize) -> Self {
+        Self::new(size)
+    }
+}

--- a/src/pipelines/embedding_pipeline/embedding_model.rs
+++ b/src/pipelines/embedding_pipeline/embedding_model.rs
@@ -1,0 +1,16 @@
+use tokenizers::Tokenizer;
+
+/// Trait for embedding models used in the embedding pipeline.
+pub trait EmbeddingModel {
+    type Options: std::fmt::Debug + Clone;
+
+    fn new(options: Self::Options, device: candle_core::Device) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    fn embed(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<Vec<f32>>;
+
+    fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer>;
+
+    fn device(&self) -> &candle_core::Device;
+}

--- a/src/pipelines/embedding_pipeline/embedding_pipeline.rs
+++ b/src/pipelines/embedding_pipeline/embedding_pipeline.rs
@@ -1,0 +1,17 @@
+use super::embedding_model::EmbeddingModel;
+use tokenizers::Tokenizer;
+
+pub struct EmbeddingPipeline<M: EmbeddingModel> {
+    pub(crate) model: M,
+    pub(crate) tokenizer: Tokenizer,
+}
+
+impl<M: EmbeddingModel> EmbeddingPipeline<M> {
+    pub fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.model.embed(&self.tokenizer, text)
+    }
+
+    pub fn device(&self) -> &candle_core::Device {
+        self.model.device()
+    }
+}

--- a/src/pipelines/embedding_pipeline/mod.rs
+++ b/src/pipelines/embedding_pipeline/mod.rs
@@ -1,0 +1,13 @@
+pub mod builder;
+pub mod embedding_model;
+pub mod embedding_pipeline;
+
+pub use builder::EmbeddingPipelineBuilder;
+pub use embedding_model::EmbeddingModel;
+pub use embedding_pipeline::EmbeddingPipeline;
+
+pub use crate::models::implementations::qwen3_embeddings::{
+    Qwen3EmbeddingModel, Qwen3EmbeddingSize,
+};
+
+pub use anyhow::Result;

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -2,6 +2,8 @@ pub(crate) mod utils;
 
 pub mod base;
 
+pub mod embedding_pipeline;
+
 pub mod fill_mask_pipeline;
 pub mod sentiment_analysis_pipeline;
 pub mod text_generation_pipeline;

--- a/tests/embedding_pipeline_tests/basic_embedding.rs
+++ b/tests/embedding_pipeline_tests/basic_embedding.rs
@@ -1,0 +1,21 @@
+use transformers::pipelines::embedding_pipeline::*;
+
+#[tokio::test]
+async fn basic_embedding() -> anyhow::Result<()> {
+    let pipeline = EmbeddingPipelineBuilder::new(Qwen3EmbeddingSize::Size0_6B)
+        .build()
+        .await?;
+    let emb = pipeline.embed("hello world")?;
+    assert!(!emb.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn select_cpu_device() -> anyhow::Result<()> {
+    let pipeline = EmbeddingPipelineBuilder::new(Qwen3EmbeddingSize::Size0_6B)
+        .cpu()
+        .build()
+        .await?;
+    assert!(pipeline.device().is_cpu());
+    Ok(())
+}

--- a/tests/embedding_pipeline_tests/main.rs
+++ b/tests/embedding_pipeline_tests/main.rs
@@ -1,0 +1,1 @@
+mod basic_embedding;


### PR DESCRIPTION
## Summary
- add a `forward_embedding` helper on Qwen3 weights
- implement a dedicated embedding model that builds its own causal mask
- include a generic embedding pipeline and builder

## Testing
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_686ab684b3508330b710c3bdc94c8517