### PR TITLE
Add batch embedding

### DIFF
--- a/src/models/implementations/qwen3_embeddings.rs
+++ b/src/models/implementations/qwen3_embeddings.rs
@@ -165,7 +165,7 @@ impl EmbeddingModel for Qwen3EmbeddingModel {
     }
 
     fn embed(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<Vec<f32>> {
-        self.embed(tokenizer, text)
+        Qwen3EmbeddingModel::embed(self, tokenizer, text)
     }
 
     fn get_tokenizer(_options: Self::Options) -> anyhow::Result<Tokenizer> {

--- a/src/pipelines/embedding_pipeline/builder.rs
+++ b/src/pipelines/embedding_pipeline/builder.rs
@@ -1,30 +1,33 @@
 use super::embedding_model::EmbeddingModel;
 use super::embedding_pipeline::EmbeddingPipeline;
 use crate::core::{global_cache, ModelOptions};
+use crate::pipelines::utils::DeviceRequest;
 
 pub struct EmbeddingPipelineBuilder<M: EmbeddingModel> {
     options: M::Options,
-    device: Option<candle_core::Device>,
+    device_request: DeviceRequest,
 }
 
 impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self { options, device: None }
+        Self {
+            options,
+            device_request: DeviceRequest::Default,
+        }
     }
 
     pub fn cpu(mut self) -> Self {
-        self.device = Some(candle_core::Device::Cpu);
+        self.device_request = DeviceRequest::Cpu;
         self
     }
 
     pub fn cuda_device(mut self, index: usize) -> Self {
-        let dev = candle_core::Device::new_cuda_with_stream(index).unwrap_or(candle_core::Device::Cpu);
-        self.device = Some(dev);
+        self.device_request = DeviceRequest::Cuda(index);
         self
     }
 
     pub fn device(mut self, device: candle_core::Device) -> Self {
-        self.device = Some(device);
+        self.device_request = DeviceRequest::Explicit(device);
         self
     }
 
@@ -33,10 +36,7 @@ impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
         M: Clone + Send + Sync + 'static,
         M::Options: ModelOptions + Clone,
     {
-        let device = match self.device {
-            Some(d) => d,
-            None => crate::pipelines::utils::load_device()?,
-        };
+        let device = self.device_request.resolve()?;
         let key = format!("{}-{:?}", self.options.cache_key(), device.location());
         let model = global_cache()
             .get_or_create(&key, || M::new(self.options.clone(), device.clone()))

--- a/src/pipelines/embedding_pipeline/embedding_model.rs
+++ b/src/pipelines/embedding_pipeline/embedding_model.rs
@@ -10,6 +10,18 @@ pub trait EmbeddingModel {
 
     fn embed(&self, tokenizer: &Tokenizer, text: &str) -> anyhow::Result<Vec<f32>>;
 
+    fn embed_batch(
+        &self,
+        tokenizer: &Tokenizer,
+        texts: &[&str],
+    ) -> anyhow::Result<Vec<Vec<f32>>> {
+        let mut results = Vec::with_capacity(texts.len());
+        for text in texts {
+            results.push(self.embed(tokenizer, text)?);
+        }
+        Ok(results)
+    }
+
     fn get_tokenizer(options: Self::Options) -> anyhow::Result<Tokenizer>;
 
     fn device(&self) -> &candle_core::Device;

--- a/src/pipelines/embedding_pipeline/embedding_pipeline.rs
+++ b/src/pipelines/embedding_pipeline/embedding_pipeline.rs
@@ -8,7 +8,12 @@ pub struct EmbeddingPipeline<M: EmbeddingModel> {
 
 impl<M: EmbeddingModel> EmbeddingPipeline<M> {
     pub fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
-        self.model.embed(&self.tokenizer, text)
+        let mut out = self.embed_batch(&[text])?;
+        Ok(out.pop().unwrap())
+    }
+
+    pub fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.model.embed_batch(&self.tokenizer, texts)
     }
 
     pub fn device(&self) -> &candle_core::Device {

--- a/src/pipelines/text_generation_pipeline/builder.rs
+++ b/src/pipelines/text_generation_pipeline/builder.rs
@@ -1,6 +1,6 @@
 use crate::core::{global_cache, ModelOptions};
 use crate::models::{Gemma3Model, Gemma3Size, Qwen3Model, Qwen3Size};
-use crate::pipelines::utils::load_device_with;
+use crate::pipelines::utils::{load_device_with, DeviceRequest};
 
 use super::parser::XmlParserBuilder;
 use super::text_generation_model::TextGenerationModel;
@@ -19,13 +19,6 @@ pub struct TextGenerationPipelineBuilder<M: TextGenerationModel> {
     top_k: Option<usize>,
     min_p: Option<f64>,
     device_request: DeviceRequest,
-}
-
-enum DeviceRequest {
-    Default,
-    Cpu,
-    Cuda(usize),
-    Explicit(Device),
 }
 
 impl<M: TextGenerationModel> TextGenerationPipelineBuilder<M> {

--- a/tests/embedding_pipeline_tests/batch_embedding.rs
+++ b/tests/embedding_pipeline_tests/batch_embedding.rs
@@ -1,0 +1,15 @@
+use transformers::pipelines::embedding_pipeline::*;
+
+#[tokio::test]
+async fn batch_embedding() -> anyhow::Result<()> {
+    let pipeline = EmbeddingPipelineBuilder::qwen3(Qwen3EmbeddingSize::Size0_6B)
+        .build()
+        .await?;
+    let inputs = ["hello", "world"];
+    let embs = pipeline.embed_batch(&inputs)?;
+    assert_eq!(embs.len(), inputs.len());
+    for emb in embs {
+        assert!(!emb.is_empty());
+    }
+    Ok(())
+}

--- a/tests/embedding_pipeline_tests/main.rs
+++ b/tests/embedding_pipeline_tests/main.rs
@@ -1,1 +1,2 @@
 mod basic_embedding;
+mod batch_embedding;


### PR DESCRIPTION
## Summary
- add `embed_batch` method to embedding model trait and pipeline
- fix recursive call in `Qwen3EmbeddingModel` implementation
- use shared `DeviceRequest` in all pipeline builders
- add tests for batch embedding

## Testing
- `cargo test --lib`
- `cargo test --doc`



------
https://chatgpt.com/codex/tasks/task_e_686c2639239083308b54be59e2578c46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for batch embedding, allowing multiple texts to be embedded in a single call.
  * Introduced a new method to obtain batch embeddings from the embedding pipeline.

* **Refactor**
  * Unified and centralized device selection logic across pipeline builders, improving device configuration options.
  * Updated builder APIs to use a new device request mechanism for more flexible hardware selection.

* **Tests**
  * Added tests to verify batch embedding functionality and ensure correct results for multiple inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->