### PR TITLE
Fix progress bar stall during downloads

### DIFF
--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -52,7 +52,9 @@ impl HfLoader {
     }
 
     pub async fn load(&self) -> anyhow::Result<PathBuf> {
-        let hf_api = HfApi::new()?;
+        let hf_api = hf_hub::api::tokio::ApiBuilder::new()
+            .with_chunk_size(None)
+            .build()?;
         let hf_repo = self.repo.clone();
         let hf_api = hf_api.model(hf_repo);
 


### PR DESCRIPTION
## Summary
- disable chunked downloads when using the loader so downloads occur in a single chunk

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_686c7cd364e48330b19a2c9c1ce11304