### PR TITLE
Refactor device builder logic + safer errors

### DIFF
--- a/src/loaders.rs
+++ b/src/loaders.rs
@@ -79,8 +79,10 @@ impl HfLoader {
             }
         }
 
-        // If we exhausted all retries, return the last error
-        Err(last_error.unwrap().into())
+        // If we exhausted all retries, return the last encountered error or a generic one
+        Err(last_error
+            .map(anyhow::Error::from)
+            .unwrap_or_else(|| anyhow::anyhow!("unknown failure")))
     }
 }
 

--- a/src/pipelines/embedding_pipeline/builder.rs
+++ b/src/pipelines/embedding_pipeline/builder.rs
@@ -2,7 +2,7 @@ use super::model::EmbeddingModel;
 use super::pipeline::EmbeddingPipeline;
 use std::sync::Arc;
 use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest};
+use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable};
 
 pub struct EmbeddingPipelineBuilder<M: EmbeddingModel> {
     options: M::Options,
@@ -17,21 +17,6 @@ impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
         }
     }
 
-    pub fn cpu(mut self) -> Self {
-        self.device_request = DeviceRequest::Cpu;
-        self
-    }
-
-    pub fn cuda_device(mut self, index: usize) -> Self {
-        self.device_request = DeviceRequest::Cuda(index);
-        self
-    }
-
-    pub fn device(mut self, device: candle_core::Device) -> Self {
-        self.device_request = DeviceRequest::Explicit(device);
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<EmbeddingPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
@@ -44,6 +29,12 @@ impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
             .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(EmbeddingPipeline { model: Arc::new(model), tokenizer })
+    }
+}
+
+impl<M: EmbeddingModel> DeviceSelectable for EmbeddingPipelineBuilder<M> {
+    fn device_request_mut(&mut self) -> &mut DeviceRequest {
+        &mut self.device_request
     }
 }
 

--- a/src/pipelines/fill_mask_pipeline/builder.rs
+++ b/src/pipelines/fill_mask_pipeline/builder.rs
@@ -1,7 +1,7 @@
 use super::model::FillMaskModel;
 use super::pipeline::FillMaskPipeline;
 use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest};
+use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable};
 
 pub struct FillMaskPipelineBuilder<M: FillMaskModel> {
     options: M::Options,
@@ -16,21 +16,6 @@ impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
         }
     }
 
-    pub fn cpu(mut self) -> Self {
-        self.device_request = DeviceRequest::Cpu;
-        self
-    }
-
-    pub fn cuda_device(mut self, index: usize) -> Self {
-        self.device_request = DeviceRequest::Cuda(index);
-        self
-    }
-
-    pub fn device(mut self, device: candle_core::Device) -> Self {
-        self.device_request = DeviceRequest::Explicit(device);
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<FillMaskPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
@@ -43,6 +28,12 @@ impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
             .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(FillMaskPipeline { model, tokenizer })
+    }
+}
+
+impl<M: FillMaskModel> DeviceSelectable for FillMaskPipelineBuilder<M> {
+    fn device_request_mut(&mut self) -> &mut DeviceRequest {
+        &mut self.device_request
     }
 }
 

--- a/src/pipelines/sentiment_analysis_pipeline/builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/builder.rs
@@ -1,7 +1,7 @@
 use super::model::SentimentAnalysisModel;
 use super::pipeline::SentimentAnalysisPipeline;
 use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest};
+use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable};
 
 pub struct SentimentAnalysisPipelineBuilder<M: SentimentAnalysisModel> {
     options: M::Options,
@@ -16,21 +16,6 @@ impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
         }
     }
 
-    pub fn cpu(mut self) -> Self {
-        self.device_request = DeviceRequest::Cpu;
-        self
-    }
-
-    pub fn cuda_device(mut self, index: usize) -> Self {
-        self.device_request = DeviceRequest::Cuda(index);
-        self
-    }
-
-    pub fn device(mut self, device: candle_core::Device) -> Self {
-        self.device_request = DeviceRequest::Explicit(device);
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<SentimentAnalysisPipeline<M>>
     where
         M: Clone + Send + Sync + 'static,
@@ -43,6 +28,12 @@ impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
             .await?;
         let tokenizer = M::get_tokenizer(self.options)?;
         Ok(SentimentAnalysisPipeline { model, tokenizer })
+    }
+}
+
+impl<M: SentimentAnalysisModel> DeviceSelectable for SentimentAnalysisPipelineBuilder<M> {
+    fn device_request_mut(&mut self) -> &mut DeviceRequest {
+        &mut self.device_request
     }
 }
 

--- a/src/pipelines/text_generation_pipeline/base_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/base_pipeline.rs
@@ -92,7 +92,8 @@ impl<M: TextGenerationModel> BasePipeline<M> {
         }
 
         // Safety: there is always at least one chunk, so last_logits is Some
-        let mut next_token = logits_processor.sample(&last_logits.unwrap())?;
+        let mut next_token =
+            logits_processor.sample(&last_logits.expect("missing logits"))?;
         generated_tokens.push(next_token);
 
         // Generate autoregressively
@@ -133,7 +134,7 @@ impl<M: TextGenerationModel> BasePipeline<M> {
         let generated_tokens_str = self
             .model_tokenizer
             .decode(&filtered_tokens, /*skip_special_tokens=*/ true)
-            .unwrap();
+            .expect("token decode failed");
 
         Ok(generated_tokens_str)
     }
@@ -180,7 +181,8 @@ impl<M: TextGenerationModel> BasePipeline<M> {
 
             let mut dec_full = tokenizer.decode_stream(false);
 
-            let mut next_token = logits_processor.sample(&last_logits.unwrap())?;
+            let mut next_token =
+                logits_processor.sample(&last_logits.expect("missing logits"))?;
             generated.push(next_token);
 
             if !eos_tokens.contains(&next_token) {

--- a/src/pipelines/text_generation_pipeline/parser.rs
+++ b/src/pipelines/text_generation_pipeline/parser.rs
@@ -237,7 +237,10 @@ impl XmlParser {
 
     /// Reset the parser state (useful for new generations)
     pub fn reset(&self) {
-        *self.state.lock().unwrap() = ParserState::default();
+        *self
+            .state
+            .lock()
+            .expect("parser lock poisoned") = ParserState::default();
     }
 
     /// Parse a complete text and return all events
@@ -267,7 +270,10 @@ impl XmlParser {
         // innermost open tag (if any). This enables true streaming behaviour: callers get
         // incremental updates instead of the whole block at close time.
         {
-            let mut state = self.state.lock().unwrap();
+            let mut state = self
+                .state
+                .lock()
+                .expect("parser lock poisoned");
 
             if state.open_tags.is_empty() {
                 // Outside of any registered tag.
@@ -338,7 +344,10 @@ impl XmlParser {
     /// Process a single character and return an event if one is ready
     fn process_char(&self, c: char) -> Vec<Event> {
         let mut events = Vec::new();
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .expect("parser lock poisoned");
 
         match c {
             '<' => {
@@ -485,7 +494,10 @@ impl XmlParser {
 
     /// Flush any remaining content and return events
     pub fn flush(&self) -> Vec<Event> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .expect("parser lock poisoned");
         let mut events = Vec::new();
 
         // Emit any remaining content

--- a/src/pipelines/text_generation_pipeline/pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/pipeline.rs
@@ -481,7 +481,11 @@ impl<M: TextGenerationModel + ToolCalling + Send> TextGenerationPipeline<M> {
         let mut tool_calls = Vec::new();
 
         for cap in tool_regex.captures_iter(text) {
-            let json_str = cap.get(1).unwrap().as_str().trim();
+            let json_str = cap
+                .get(1)
+                .expect("expected capture group")
+                .as_str()
+                .trim();
             match serde_json::from_str::<RawToolCall>(json_str) {
                 Ok(raw_call) => {
                     tool_calls.push(ToolCallInvocation {

--- a/src/pipelines/text_generation_pipeline/xml_pipeline.rs
+++ b/src/pipelines/text_generation_pipeline/xml_pipeline.rs
@@ -538,7 +538,11 @@ impl<M: TextGenerationModel + ToolCalling + Send> XmlGenerationPipeline<M> {
         let mut tool_calls = Vec::new();
 
         for cap in tool_regex.captures_iter(text) {
-            let json_str = cap.get(1).unwrap().as_str().trim();
+            let json_str = cap
+                .get(1)
+                .expect("expected capture group")
+                .as_str()
+                .trim();
             match serde_json::from_str::<RawToolCall>(json_str) {
                 Ok(raw_call) => {
                     tool_calls.push(ToolCallInvocation {

--- a/src/pipelines/utils/mod.rs
+++ b/src/pipelines/utils/mod.rs
@@ -51,6 +51,30 @@ impl DeviceRequest {
     }
 }
 
+/// Trait providing convenience methods for pipeline builders to select a device.
+pub trait DeviceSelectable: Sized {
+    /// Returns a mutable reference to the builder's internal [`DeviceRequest`].
+    fn device_request_mut(&mut self) -> &mut DeviceRequest;
+
+    /// Force the pipeline to run on CPU.
+    fn cpu(mut self) -> Self {
+        *self.device_request_mut() = DeviceRequest::Cpu;
+        self
+    }
+
+    /// Select a specific CUDA device by index.
+    fn cuda_device(mut self, index: usize) -> Self {
+        *self.device_request_mut() = DeviceRequest::Cuda(index);
+        self
+    }
+
+    /// Provide an explicit [`Device`].
+    fn device(mut self, device: Device) -> Self {
+        *self.device_request_mut() = DeviceRequest::Explicit(device);
+        self
+    }
+}
+
 /// Utility to generate a cache key combining model options and device location.
 pub fn build_cache_key<O: ModelOptions>(options: &O, device: &Device) -> String {
     format!("{}-{:?}", options.cache_key(), device.location())


### PR DESCRIPTION
## Summary
- extract `DeviceSelectable` trait for pipeline builders
- implement trait across pipeline builders to remove duplicate device logic
- improve loader retry error handling
- replace unsafe `unwrap()` calls with `expect()` messages

## Testing
- `cargo check`
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_686c9284f6388330b1d6e6a18f5033f6