### PR TITLE
Refactor pipeline builders

### DIFF
--- a/src/pipelines/embedding_pipeline/builder.rs
+++ b/src/pipelines/embedding_pipeline/builder.rs
@@ -1,26 +1,20 @@
 use super::model::EmbeddingModel;
 use super::pipeline::EmbeddingPipeline;
+use crate::core::ModelOptions;
+use crate::pipelines::utils::{BasePipelineBuilder, DeviceRequest, DeviceSelectable, StandardPipelineBuilder};
 use std::sync::Arc;
-use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable, BasePipelineBuilder};
 
-pub struct EmbeddingPipelineBuilder<M: EmbeddingModel> {
-    options: M::Options,
-    device_request: DeviceRequest,
-}
+pub struct EmbeddingPipelineBuilder<M: EmbeddingModel>(StandardPipelineBuilder<M::Options>);
 
 impl<M: EmbeddingModel> EmbeddingPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self {
-            options,
-            device_request: DeviceRequest::Default,
-        }
+        Self(StandardPipelineBuilder::new(options))
     }
 }
 
 impl<M: EmbeddingModel> DeviceSelectable for EmbeddingPipelineBuilder<M> {
     fn device_request_mut(&mut self) -> &mut DeviceRequest {
-        &mut self.device_request
+        self.0.device_request_mut()
     }
 }
 
@@ -34,11 +28,11 @@ where
     type Options = M::Options;
 
     fn options(&self) -> &Self::Options {
-        &self.options
+        &self.0.options
     }
     
     fn device_request(&self) -> &DeviceRequest {
-        &self.device_request
+        &self.0.device_request
     }
 
     fn create_model(options: Self::Options, device: candle_core::Device) -> anyhow::Result<M> {
@@ -50,9 +44,9 @@ where
     }
     
     fn construct_pipeline(model: M, tokenizer: tokenizers::Tokenizer) -> anyhow::Result<Self::Pipeline> {
-        Ok(EmbeddingPipeline { 
-            model: Arc::new(model), 
-            tokenizer 
+        Ok(EmbeddingPipeline {
+            model: Arc::new(model),
+            tokenizer,
         })
     }
 }

--- a/src/pipelines/fill_mask_pipeline/builder.rs
+++ b/src/pipelines/fill_mask_pipeline/builder.rs
@@ -1,25 +1,19 @@
 use super::model::FillMaskModel;
 use super::pipeline::FillMaskPipeline;
-use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable, BasePipelineBuilder};
+use crate::core::ModelOptions;
+use crate::pipelines::utils::{BasePipelineBuilder, DeviceRequest, DeviceSelectable, StandardPipelineBuilder};
 
-pub struct FillMaskPipelineBuilder<M: FillMaskModel> {
-    options: M::Options,
-    device_request: DeviceRequest,
-}
+pub struct FillMaskPipelineBuilder<M: FillMaskModel>(StandardPipelineBuilder<M::Options>);
 
 impl<M: FillMaskModel> FillMaskPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self {
-            options,
-            device_request: DeviceRequest::Default,
-        }
+        Self(StandardPipelineBuilder::new(options))
     }
 }
 
 impl<M: FillMaskModel> DeviceSelectable for FillMaskPipelineBuilder<M> {
     fn device_request_mut(&mut self) -> &mut DeviceRequest {
-        &mut self.device_request
+        self.0.device_request_mut()
     }
 }
 
@@ -33,11 +27,11 @@ where
     type Options = M::Options;
 
     fn options(&self) -> &Self::Options {
-        &self.options
+        &self.0.options
     }
     
     fn device_request(&self) -> &DeviceRequest {
-        &self.device_request
+        &self.0.device_request
     }
 
     fn create_model(options: Self::Options, device: candle_core::Device) -> anyhow::Result<M> {

--- a/src/pipelines/reranker_pipeline/builder.rs
+++ b/src/pipelines/reranker_pipeline/builder.rs
@@ -1,26 +1,20 @@
 use super::model::RerankModel;
 use super::pipeline::RerankPipeline;
+use crate::core::ModelOptions;
+use crate::pipelines::utils::{BasePipelineBuilder, DeviceRequest, DeviceSelectable, StandardPipelineBuilder};
 use std::sync::Arc;
-use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable, BasePipelineBuilder};
 
-pub struct RerankPipelineBuilder<M: RerankModel> {
-    options: M::Options,
-    device_request: DeviceRequest,
-}
+pub struct RerankPipelineBuilder<M: RerankModel>(StandardPipelineBuilder<M::Options>);
 
 impl<M: RerankModel> RerankPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self {
-            options,
-            device_request: DeviceRequest::Default,
-        }
+        Self(StandardPipelineBuilder::new(options))
     }
 }
 
 impl<M: RerankModel> DeviceSelectable for RerankPipelineBuilder<M> {
     fn device_request_mut(&mut self) -> &mut DeviceRequest {
-        &mut self.device_request
+        self.0.device_request_mut()
     }
 }
 
@@ -34,11 +28,11 @@ where
     type Options = M::Options;
 
     fn options(&self) -> &Self::Options {
-        &self.options
+        &self.0.options
     }
     
     fn device_request(&self) -> &DeviceRequest {
-        &self.device_request
+        &self.0.device_request
     }
 
     fn create_model(options: Self::Options, device: candle_core::Device) -> anyhow::Result<M> {
@@ -50,9 +44,9 @@ where
     }
     
     fn construct_pipeline(model: M, tokenizer: tokenizers::Tokenizer) -> anyhow::Result<Self::Pipeline> {
-        Ok(RerankPipeline { 
-            model: Arc::new(model), 
-            tokenizer 
+        Ok(RerankPipeline {
+            model: Arc::new(model),
+            tokenizer,
         })
     }
 }

--- a/src/pipelines/sentiment_analysis_pipeline/builder.rs
+++ b/src/pipelines/sentiment_analysis_pipeline/builder.rs
@@ -1,25 +1,19 @@
 use super::model::SentimentAnalysisModel;
 use super::pipeline::SentimentAnalysisPipeline;
-use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable, BasePipelineBuilder};
+use crate::core::ModelOptions;
+use crate::pipelines::utils::{BasePipelineBuilder, DeviceRequest, DeviceSelectable, StandardPipelineBuilder};
 
-pub struct SentimentAnalysisPipelineBuilder<M: SentimentAnalysisModel> {
-    options: M::Options,
-    device_request: DeviceRequest,
-}
+pub struct SentimentAnalysisPipelineBuilder<M: SentimentAnalysisModel>(StandardPipelineBuilder<M::Options>);
 
 impl<M: SentimentAnalysisModel> SentimentAnalysisPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self {
-            options,
-            device_request: DeviceRequest::Default,
-        }
+        Self(StandardPipelineBuilder::new(options))
     }
 }
 
 impl<M: SentimentAnalysisModel> DeviceSelectable for SentimentAnalysisPipelineBuilder<M> {
     fn device_request_mut(&mut self) -> &mut DeviceRequest {
-        &mut self.device_request
+        self.0.device_request_mut()
     }
 }
 
@@ -33,11 +27,11 @@ where
     type Options = M::Options;
 
     fn options(&self) -> &Self::Options {
-        &self.options
+        &self.0.options
     }
     
     fn device_request(&self) -> &DeviceRequest {
-        &self.device_request
+        &self.0.device_request
     }
 
     fn create_model(options: Self::Options, device: candle_core::Device) -> anyhow::Result<M> {

--- a/src/pipelines/utils/builder.rs
+++ b/src/pipelines/utils/builder.rs
@@ -8,7 +8,6 @@
 //!
 //! The `BasePipelineBuilder` trait captures this common pattern.
 
-use std::sync::Arc;
 use anyhow::Result;
 use crate::core::{global_cache, ModelOptions};
 use super::{build_cache_key, DeviceRequest, DeviceSelectable};

--- a/src/pipelines/zero_shot_classification_pipeline/builder.rs
+++ b/src/pipelines/zero_shot_classification_pipeline/builder.rs
@@ -1,25 +1,19 @@
 use super::model::ZeroShotClassificationModel;
 use super::pipeline::ZeroShotClassificationPipeline;
-use crate::core::{global_cache, ModelOptions};
-use crate::pipelines::utils::{build_cache_key, DeviceRequest, DeviceSelectable, BasePipelineBuilder};
+use crate::core::ModelOptions;
+use crate::pipelines::utils::{BasePipelineBuilder, DeviceRequest, DeviceSelectable, StandardPipelineBuilder};
 
-pub struct ZeroShotClassificationPipelineBuilder<M: ZeroShotClassificationModel> {
-    options: M::Options,
-    device_request: DeviceRequest,
-}
+pub struct ZeroShotClassificationPipelineBuilder<M: ZeroShotClassificationModel>(StandardPipelineBuilder<M::Options>);
 
 impl<M: ZeroShotClassificationModel> ZeroShotClassificationPipelineBuilder<M> {
     pub fn new(options: M::Options) -> Self {
-        Self {
-            options,
-            device_request: DeviceRequest::Default,
-        }
+        Self(StandardPipelineBuilder::new(options))
     }
 }
 
 impl<M: ZeroShotClassificationModel> DeviceSelectable for ZeroShotClassificationPipelineBuilder<M> {
     fn device_request_mut(&mut self) -> &mut DeviceRequest {
-        &mut self.device_request
+        self.0.device_request_mut()
     }
 }
 
@@ -33,11 +27,11 @@ where
     type Options = M::Options;
 
     fn options(&self) -> &Self::Options {
-        &self.options
+        &self.0.options
     }
     
     fn device_request(&self) -> &DeviceRequest {
-        &self.device_request
+        &self.0.device_request
     }
 
     fn create_model(options: Self::Options, device: candle_core::Device) -> anyhow::Result<M> {


### PR DESCRIPTION
## Summary
- simplify pipeline builder structs by wrapping `StandardPipelineBuilder`
- clean up unused import in utilities

## Testing
- `cargo test --lib --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686cd40bb1fc8330b401d37a80655811